### PR TITLE
Fix custom fields missing in estimate request emails

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -771,19 +771,13 @@ private function _make_estimate_request_row($data) {
                 "files_data" => $files_data
             );
 
-            //create notification and update description with extra data
+            // create notification with description included
             $notification_id = log_notification("estimate_request_received", array(
                 "estimate_request_id" => $save_id,
                 "user_id" => $this->login_user->id,
-                "assigned_to" => $assigned_to ? $assigned_to : 0
+                "assigned_to" => $assigned_to ? $assigned_to : 0,
+                "description" => json_encode($notification_data)
             ));
-
-            if ($notification_id) {
-                $this->Notifications_model->ci_save(array(
-                    "id" => $notification_id,
-                    "description" => json_encode($notification_data)
-                ), $notification_id);
-            }
 
             $this->session->setFlashdata("success_message", app_lang("estimate_submission_message"));
 

--- a/app/Controllers/Notification_processor.php
+++ b/app/Controllers/Notification_processor.php
@@ -67,7 +67,8 @@ class Notification_processor extends App_Controller {
             "subscription_id" => get_array_value($data, "subscription_id"),
             "expense_id" => get_array_value($data, "expense_id"),
             "proposal_comment_id" => get_array_value($data, "proposal_comment_id"),
-            "reminder_log_id" => get_array_value($data, "reminder_log_id")
+            "reminder_log_id" => get_array_value($data, "reminder_log_id"),
+            "description" => get_array_value($data, "description")
         );
 
         // Fetch custom fields for estimate request notifications

--- a/app/Controllers/Request_estimate.php
+++ b/app/Controllers/Request_estimate.php
@@ -215,20 +215,13 @@ function save_estimate_request() {
             "files_data" => $files_data
         );
 
-        // Create notification with initial data
+        // Create notification including all data at once
         $notification_id = log_notification("estimate_request_received", array(
             "estimate_request_id" => $save_id,
             "user_id" => $user_id,
-            "assigned_to" => $assigned_to ? $assigned_to : 0
+            "assigned_to" => $assigned_to ? $assigned_to : 0,
+            "description" => json_encode($notification_data)
         ));
-
-        // Update notification with complex data in description field
-        if ($notification_id) {
-            $this->Notifications_model->ci_save(array(
-                "id" => $notification_id,
-                "description" => json_encode($notification_data)
-            ), $notification_id);
-        }
 
         echo json_encode(array("success" => true, 'message' => app_lang('estimate_submission_message')));
     } else {

--- a/app/Models/Notifications_model.php
+++ b/app/Models/Notifications_model.php
@@ -554,7 +554,7 @@ class Notifications_model extends Crud_model {
 
         $data = array(
             "user_id" => $user_id,
-            "description" => "",
+            "description" => get_array_value($options, "description") ? get_array_value($options, "description") : "",
             "created_at" => get_current_utc_time(),
             "notify_to" => $web_notify_to,
             "read_by" => "",


### PR DESCRIPTION
## Summary
- store notification description when creating notifications
- include description payload in estimate request controllers
- pass description parameter through Notification_processor

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701f4b25f48332b119cea573c53480