### PR TITLE
Fix estimate request email placeholders

### DIFF
--- a/app/Controllers/Notification_processor.php
+++ b/app/Controllers/Notification_processor.php
@@ -72,7 +72,7 @@ class Notification_processor extends App_Controller {
         );
 
         // Fetch custom fields for estimate request notifications
-       if ($event === "estimate_request_submitted"
+       if (($event === "estimate_request_submitted" || $event === "estimate_request_received")
     && $options["estimate_request_id"]) {
 
     // Pull every custom field for this request in one shot


### PR DESCRIPTION
## Summary
- fetch custom fields for `estimate_request_received` events

## Testing
- `php -l app/Controllers/Notification_processor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68702fc8717c83329e1f568229a42a1b