### PR TITLE
Fix custom field arrays in email templates

### DIFF
--- a/app/Helpers/notifications_helper.php
+++ b/app/Helpers/notifications_helper.php
@@ -1134,7 +1134,11 @@ function parse_email_template($template, $data) {
     if (isset($data['CUSTOM_FIELD_VALUES']) && is_array($data['CUSTOM_FIELD_VALUES'])) {
         $custom_field_rows = '';
         foreach ($data['CUSTOM_FIELD_VALUES'] as $field) {
-            $custom_field_rows .= '<tr><td><strong>' . htmlspecialchars($field['title']) . '</strong></td><td>' . htmlspecialchars($field['value']) . '</td></tr>';
+            $value = $field['value'];
+            if (is_array($value)) {
+                $value = implode(', ', $value);
+            }
+            $custom_field_rows .= '<tr><td><strong>' . htmlspecialchars($field['title']) . '</strong></td><td>' . htmlspecialchars($value) . '</td></tr>';
         }
         $template = preg_replace('/{CUSTOM_FIELD_VALUES}.*?{\/CUSTOM_FIELD_VALUES}/s', $custom_field_rows, $template);
         $template = str_replace('{CUSTOM_FIELD_VALUES}', $custom_field_rows, $template);


### PR DESCRIPTION
## Summary
- ensure custom field values that come in as arrays render cleanly in email templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687031f3a8f483329d117584350d3df9