### PR TITLE
Populate lead name custom fields

### DIFF
--- a/app/Controllers/Collect_leads.php
+++ b/app/Controllers/Collect_leads.php
@@ -95,6 +95,7 @@ class Collect_leads extends App_Controller {
         }
 
         save_custom_fields("leads", $lead_id, 1, "staff");
+        set_lead_name_custom_fields($lead_id, $first_name, $last_name);
 
         //lead created, create a contact on that lead
         //if first name or last name or email is not provided, don't create a contact

--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -754,6 +754,10 @@ class Leads extends Security_Controller {
 
             save_custom_fields("lead_contacts", $save_id, $this->login_user->is_admin, $this->login_user->user_type);
 
+            if (!$contact_id && get_array_value($user_data, 'is_primary_contact')) {
+                set_lead_name_custom_fields($client_id, $user_data['first_name'], $user_data['last_name']);
+            }
+
             //has changed the existing primary contact? updete previous primary contact and set is_primary_contact=0
             if ($is_primary_contact) {
                 $user_data = array("is_primary_contact" => 0);
@@ -1368,6 +1372,8 @@ class Leads extends Security_Controller {
         //add lead id to contact data
         $lead_contact_data["client_id"] = $saved_id;
         $this->Users_model->ci_save($lead_contact_data);
+
+        set_lead_name_custom_fields($saved_id, get_array_value($lead_contact_data, 'first_name'), get_array_value($lead_contact_data, 'last_name'));
         return true;
     }
 

--- a/app/Controllers/Request_estimate.php
+++ b/app/Controllers/Request_estimate.php
@@ -161,6 +161,7 @@ function save_estimate_request() {
 
             $lead_contact_data = clean_data($lead_contact_data);
             $lead_contact_id = $this->Users_model->ci_save($lead_contact_data);
+            set_lead_name_custom_fields($lead_id, $form_data['first_name'], $form_data['last_name']);
         }
 
         $request_data = array(

--- a/app/Helpers/general_helper.php
+++ b/app/Helpers/general_helper.php
@@ -3461,3 +3461,32 @@ if (!function_exists('add_client_note')) {
         return false;
     }
 }
+
+//populate first and last name custom fields for leads
+if (!function_exists('set_lead_name_custom_fields')) {
+    function set_lead_name_custom_fields($lead_id, $first_name = '', $last_name = '') {
+        if (!$lead_id) {
+            return;
+        }
+
+        $Custom_field_values_model = model('App\Models\Custom_field_values_model');
+
+        if ($first_name !== null) {
+            $Custom_field_values_model->upsert([
+                'related_to_type' => 'leads',
+                'related_to_id' => $lead_id,
+                'custom_field_id' => 277,
+                'value' => $first_name
+            ]);
+        }
+
+        if ($last_name !== null) {
+            $Custom_field_values_model->upsert([
+                'related_to_type' => 'leads',
+                'related_to_id' => $lead_id,
+                'custom_field_id' => 278,
+                'value' => $last_name
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to upsert first/last name custom fields for leads
- use new helper when creating a lead from the public form
- update primary contact creation to fill custom fields
- populate custom fields on lead import and estimate requests

## Testing
- `php -l app/Helpers/general_helper.php`
- `php -l app/Controllers/Collect_leads.php`
- `php -l app/Controllers/Leads.php`
- `php -l app/Controllers/Request_estimate.php`

------
https://chatgpt.com/codex/tasks/task_e_6875994252508332876afebb8a6a8b9d