### PR TITLE
Disable cropping for image custom field

### DIFF
--- a/app/Views/custom_fields/input_image.php
+++ b/app/Views/custom_fields/input_image.php
@@ -11,19 +11,12 @@ if ($value) {
 <div class="custom-field-image-upload">
     <div class="file-upload btn btn-default btn-sm">
         <span><i data-feather="upload" class="icon-14"></i> <?php echo app_lang('upload'); ?></span>
-        <input id="custom_field_file_<?php echo $field_info->id; ?>" class="cropbox-upload upload" name="custom_field_file_<?php echo $field_info->id; ?>" type="file" data-height="200" data-width="200" data-preview-container="#custom_field_image_preview_<?php echo $field_info->id; ?>" data-input-field="#custom_field_<?php echo $field_info->id; ?>" />
+        <input id="custom_field_file_<?php echo $field_info->id; ?>" class="upload" name="custom_field_file_<?php echo $field_info->id; ?>" type="file" <?php echo $field_info->required ? 'required' : ''; ?> />
     </div>
     <div class="mt10">
         <img id="custom_field_image_preview_<?php echo $field_info->id; ?>" src="<?php echo $preview; ?>" style="max-height:80px;" />
     </div>
-    <?php
-    echo form_input(array(
-        "id" => "custom_field_" . $field_info->id,
-        "name" => "custom_field_" . $field_info->id,
-        "value" => $value,
-        "type" => "hidden",
-        "data-rule-required" => $field_info->required ? true : "false",
-        "data-msg-required" => app_lang("field_required"),
-    ));
-    ?>
+    <?php if ($preview) { ?>
+        <input type="hidden" id="custom_field_<?php echo $field_info->id; ?>" name="custom_field_<?php echo $field_info->id; ?>" value="<?php echo $value; ?>" />
+    <?php } ?>
 </div>


### PR DESCRIPTION
## Summary
- skip CropBox in image custom fields
- support direct file uploads for custom field images

## Testing
- `php -l app/Views/custom_fields/input_image.php`
- `php -l app/Helpers/general_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_6876c9c5c1a08332950c72ab5d0d8264