### PR TITLE
Add Created Date filter for clients

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -221,6 +221,8 @@ function list_data() {
             "owner_id" => $show_own_clients_only_user_id ? $show_own_clients_only_user_id : $this->request->getPost("owner_id"),
             "client_groups" => $this->allowed_client_groups,
             "label_id" => $this->request->getPost('label_id'),
+            "start_date" => $this->request->getPost("start_date"),
+            "end_date" => $this->request->getPost("end_date"),
             "is_lead" => 0 // Explicitly filter for clients only
         );
 

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -71,6 +71,7 @@
                 {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
                 <?php echo $custom_field_filters; ?>
             ],
+            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: columns,
             printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], '<?php echo $custom_field_headers; ?>'),
             xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], '<?php echo $custom_field_headers; ?>'),


### PR DESCRIPTION
## Summary
- allow filtering clients list by created date
- add date range picker to clients list view

## Testing
- `composer test` *(fails: no composer)*

------
https://chatgpt.com/codex/tasks/task_e_68794ec7ce0c8332a4cfcc3232e34684