### PR TITLE
Add account type column and filter to client list

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -216,6 +216,7 @@ function list_data() {
             "custom_fields" => $custom_fields,
             "custom_field_filter" => $this->prepare_custom_field_filter_values("clients", $this->login_user->is_admin, $this->login_user->user_type),
             "group_id" => $this->request->getPost("group_id"),
+            "account_type" => $this->request->getPost("account_type"),
             "show_own_clients_only_user_id" => $show_own_clients_only_user_id,
             "quick_filter" => $this->request->getPost("quick_filter"),
             "owner_id" => $show_own_clients_only_user_id ? $show_own_clients_only_user_id : $this->request->getPost("owner_id"),
@@ -333,6 +334,7 @@ private function _make_row($data, $custom_fields) {
         anchor(get_uri("clients/view/" . $data->id), $data->company_name),
         $data->primary_contact ? $primary_contact : "",
         $data->phone,
+        ucfirst($data->account_type),
         $created_date, // Add created_date here
         $group_list,
         $owner_name, // This now reflects the owner_id

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -74,6 +74,11 @@ function get_details($options = array()) {
         $where .= " AND FIND_IN_SET('$group_id', $clients_table.group_ids)";
     }
 
+    $account_type = $this->_get_clean_value($options, "account_type");
+    if ($account_type) {
+        $where .= " AND $clients_table.type='$account_type'";
+    }
+
     $quick_filter = $this->_get_clean_value($options, "quick_filter");
     if ($quick_filter) {
         $where .= $this->make_quick_filter_query($quick_filter, $clients_table, $projects_table, $invoices_table, $invoice_payments_table, $estimates_table, $estimate_requests_table, $tickets_table, $orders_table, $proposals_table);
@@ -120,6 +125,7 @@ function get_details($options = array()) {
         "id" => $clients_table . ".id",
         "company_name" => $clients_table . ".company_name",
         "created_date" => $clients_table . ".created_date",
+        "account_type" => $clients_table . ".type",
         "primary_contact" => $users_table . ".first_name",
         "status" => "lead_status_title",
         "owner_name" => "owner_details.owner_name",
@@ -148,13 +154,15 @@ function get_details($options = array()) {
 
         $where .= " OR owner_details.owner_name LIKE '%$search_by%' ESCAPE '!' ";
         $where .= " OR $lead_status_table.title LIKE '%$search_by%' ESCAPE '!' ";
+        $where .= " OR $clients_table.type LIKE '%$search_by%' ESCAPE '!' ";
         $where .= $this->get_custom_field_search_query($clients_table, $custom_field_type, $search_by);
 
         $where .= " )";
     }
 
-    $sql = "SELECT SQL_CALC_FOUND_ROWS $clients_table.*, 
-                   CONCAT($users_table.first_name, ' ', $users_table.last_name) AS primary_contact, 
+    $sql = "SELECT SQL_CALC_FOUND_ROWS $clients_table.*,
+                   $clients_table.type AS account_type,
+                   CONCAT($users_table.first_name, ' ', $users_table.last_name) AS primary_contact,
                    $users_table.id AS primary_contact_id, 
                    $users_table.image AS contact_avatar, 
                    project_table.total_projects, 

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -19,6 +19,11 @@
 
         var ignoreSavedFilter = false;
         var quick_filters_dropdown = <?php echo view("clients/quick_filters_dropdown"); ?>;
+        var type_dropdown = [
+            {id: "", text: "- <?php echo app_lang('type'); ?> -"},
+            {id: "person", text: "<?php echo app_lang('person'); ?>"},
+            {id: "organization", text: "<?php echo app_lang('organization'); ?>"}
+        ];
         if (window.selectedClientQuickFilter) {
             var filterIndex = quick_filters_dropdown.findIndex(x => x.id === window.selectedClientQuickFilter);
             if (filterIndex > -1) {
@@ -33,6 +38,7 @@
             {title: "<?php echo app_lang('name') ?>", "class": "all", order_by: "company_name"},
             {title: "<?php echo app_lang('primary_contact') ?>", order_by: "primary_contact"},
             {title: "<?php echo app_lang('phone') ?>", order_by: "phone"},
+            {title: "<?php echo app_lang('type') ?>", order_by: "account_type"},
               {title: "Created Date", order_by: "created_date"},
             {title: "<?php echo app_lang('client_groups') ?>", order_by: "client_groups"},
             {title: "<?php echo app_lang('owner') ?>", order_by: "client_owner"},
@@ -69,12 +75,13 @@
                     {name: "owner_id", class: "w200", options: <?php echo $team_members_dropdown; ?>},
                 <?php } ?>
                 {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
+                {name: "account_type", class: "w200", options: type_dropdown},
                 <?php echo $custom_field_filters; ?>
             ],
             rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: columns,
-            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], '<?php echo $custom_field_headers; ?>'),
-            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], '<?php echo $custom_field_headers; ?>'),
+            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),
+            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),
             ajax: {
                 dataSrc: function (data) {
                     console.log('Table Data:', data);


### PR DESCRIPTION
## Summary
- display account type (person/organization) in client list
- filter client list by account type
- include account type in table print/xls columns

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Views/clients/clients_list.php`


------
https://chatgpt.com/codex/tasks/task_e_68797774ab008332b714c02996dff5e9