### PR TITLE
Add client status filter

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -217,6 +217,7 @@ function list_data() {
             "custom_field_filter" => $this->prepare_custom_field_filter_values("clients", $this->login_user->is_admin, $this->login_user->user_type),
             "group_id" => $this->request->getPost("group_id"),
             "account_type" => $this->request->getPost("account_type"),
+            "status" => $this->request->getPost("status"),
             "show_own_clients_only_user_id" => $show_own_clients_only_user_id,
             "quick_filter" => $this->request->getPost("quick_filter"),
             "owner_id" => $show_own_clients_only_user_id ? $show_own_clients_only_user_id : $this->request->getPost("owner_id"),

--- a/app/Views/clients/client_statuses.php
+++ b/app/Views/clients/client_statuses.php
@@ -1,0 +1,11 @@
+<?php
+
+$client_statuses_dropdown = array(array("id" => "", "text" => "- " . app_lang("status") . " -"));
+if (isset($statuses)) {
+    foreach ($statuses as $status) {
+        $client_statuses_dropdown[] = array("id" => $status->id, "text" => $status->title);
+    }
+}
+
+echo json_encode($client_statuses_dropdown);
+?>

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -76,6 +76,7 @@
                 <?php } ?>
                 {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
                 {name: "account_type", class: "w200", options: type_dropdown},
+                {name: "status", class: "w200", options: <?php echo view("clients/client_statuses"); ?>},
                 <?php echo $custom_field_filters; ?>
             ],
             rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],


### PR DESCRIPTION
## Summary
- allow filtering client list by status
- add dropdown for status selection

## Testing
- `php -l app/Views/clients/client_statuses.php`
- `php -l app/Views/clients/clients_list.php`
- `php -l app/Controllers/Clients.php`


------
https://chatgpt.com/codex/tasks/task_e_687986106ad48332811115011dcdc9c4