### PR TITLE
Add estimated close date filter

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -225,6 +225,9 @@ function list_data() {
             "label_id" => $this->request->getPost('label_id'),
             "start_date" => $this->request->getPost("start_date"),
             "end_date" => $this->request->getPost("end_date"),
+            // Date range filter for Estimated Close Date custom field
+            "ec_start_date" => $this->request->getPost("estimated_close_start_date"),
+            "ec_end_date" => $this->request->getPost("estimated_close_end_date"),
             "is_lead" => 0 // Explicitly filter for clients only
         );
 
@@ -1896,6 +1899,9 @@ private function _save_a_row_of_excel_data($row_data) {
         $view_data['can_edit_clients'] = $this->can_edit_clients();
         $view_data["team_members_dropdown"] = $this->get_team_members_dropdown(true);
         $view_data['labels_dropdown'] = json_encode($this->make_labels_dropdown("client", "", true));
+
+        // Pass the custom field id for Estimated Close Date to the view
+        $view_data['estimated_close_cf_id'] = 167; // see general_helper mapping
 
         return $this->template->view("clients/clients_list", $view_data);
     }

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -93,6 +93,16 @@ function get_details($options = array()) {
         $where .= " AND DATE($clients_table.created_date)<='$end_date'";
     }
 
+    // Range filter for Estimated Close Date custom field (id 167)
+    $ec_start_date = $this->_get_clean_value($options, "ec_start_date");
+    if ($ec_start_date) {
+        $where .= " AND DATE(cfvt_167.value)>='$ec_start_date'";
+    }
+    $ec_end_date = $this->_get_clean_value($options, "ec_end_date");
+    if ($ec_end_date) {
+        $where .= " AND DATE(cfvt_167.value)<='$ec_end_date'";
+    }
+
     $label_id = $this->_get_clean_value($options, "label_id");
     if ($label_id) {
         $where .= " AND (FIND_IN_SET('$label_id', $clients_table.labels)) ";

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -79,7 +79,10 @@
                 {name: "status", class: "w200", options: <?php echo view("clients/client_statuses"); ?>},
                 <?php echo $custom_field_filters; ?>
             ],
-            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true},
+                {startDate: {name: "estimated_close_start_date", value: ""}, endDate: {name: "estimated_close_end_date", value: ""}, label: "Estimated Close", showClearButton: true}
+            ],
             columns: columns,
             printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),
             xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),


### PR DESCRIPTION
## Summary
- allow filtering clients by custom field 'Estimated Close Date'
- pass filter values in `list_data` and view
- handle date range logic in the model

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Views/clients/clients_list.php`


------
https://chatgpt.com/codex/tasks/task_e_68799a18e29483328f85a7d8fe9a54e9