### PR TITLE
Add Google Maps autocomplete to lead modal

### DIFF
--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -11,6 +11,9 @@
 </div>
 <?php echo form_close(); ?>
 
+<!-- Google Maps API Script -->
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initAutocomplete" async defer></script>
+
 <script type="text/javascript">
     $(document).ready(function () {
         $("#lead-form").appForm({
@@ -26,8 +29,131 @@
                 }
             }
         });
+
         setTimeout(function () {
             $("#company_name").focus();
         }, 200);
+
+        // Prevent browser autofill on address field
+        var addressInput = $('#address');
+        addressInput.attr('autocomplete', 'new-address');
+        addressInput.on('focus', function () {
+            $(this).attr('autocomplete', 'new-address');
+        });
+
+        // Dynamic logic: override lead source based on location
+        $("#state, #city").on("change keyup", updateLeadSource);
     });
-</script>    
+
+    function updateLeadSource() {
+        var cityVal = $("#city").val().trim().toLowerCase();
+        var provinceVal = $("#state").val();
+
+        if (!provinceVal) {
+            $("#lead_source_id").val("").trigger("change");
+            return;
+        }
+
+        var sourceMap = {
+            "New Brunswick": 1,
+            "Nova Scotia": 1,
+            "Prince Edward Island": 1,
+            "Quebec": 5,
+            "Ontario": 6,
+            "Manitoba": 3,
+            "Northwest Territories": 3,
+            "British Columbia": 3
+        };
+
+        if (provinceVal === "British Columbia") {
+            var bcCitiesKeywords = [
+                "vancouver", "burnaby", "richmond", "surrey", "delta", "new westminster",
+                "langley", "white rock", "maple ridge", "pitt meadows", "coquitlam",
+                "port coquitlam", "port moody", "north vancouver", "west vancouver",
+                "belcarra", "anmore", "bowen island", "lions bay",
+                "abbotsford", "chilliwack", "mission", "kent", "agassiz",
+                "harrison hot springs", "hope",
+                "sechelt", "gibsons",
+                "victoria", "saanich", "oak bay", "esquimalt", "view royal", "colwood",
+                "langford", "metchosin", "highlands", "sooke", "central saanich", "north saanich",
+                "sidney", "duncan", "north cowichan", "lake cowichan", "ladysmith", "nanaimo",
+                "lantzville", "parksville", "qualicum beach", "port alberni", "tofino",
+                "ucluelet", "courtenay", "comox", "cumberland", "campbell river", "gold river",
+                "tahsis", "zeballos", "port hardy", "port mcneill", "port alice", "alert bay"
+            ];
+
+            for (var i = 0; i < bcCitiesKeywords.length; i++) {
+                if (cityVal.indexOf(bcCitiesKeywords[i]) !== -1) {
+                    $("#lead_source_id").val("2").trigger("change");
+                    return;
+                }
+            }
+            $("#lead_source_id").val("3").trigger("change");
+            return;
+        }
+
+        var mappedId = sourceMap[provinceVal] ? sourceMap[provinceVal] : "";
+        $("#lead_source_id").val(mappedId).trigger("change");
+    }
+
+    // Google Places Autocomplete Initialization
+    function initAutocomplete() {
+        var addressInput = document.getElementById('address');
+        var autocomplete = new google.maps.places.Autocomplete(addressInput, {
+            types: ['address'],
+            componentRestrictions: { country: ['ca'] },
+            fields: ['address_components', 'geometry', 'formatted_address']
+        });
+
+        autocomplete.addListener('place_changed', function () {
+            var place = autocomplete.getPlace();
+            var addressComponents = place.address_components;
+
+            $('#address').val('');
+            $('#city').val('');
+            $('#state').val('');
+            $('#zip').val('');
+            $('#country').val('');
+
+            var streetNumber = '';
+            var route = '';
+            var city = '';
+            var province = '';
+            var postalCode = '';
+            var country = '';
+
+            for (var i = 0; i < addressComponents.length; i++) {
+                var component = addressComponents[i];
+                var types = component.types;
+
+                if (types.includes('street_number')) {
+                    streetNumber = component.short_name;
+                }
+                if (types.includes('route')) {
+                    route = component.long_name;
+                }
+                if (types.includes('locality')) {
+                    city = component.long_name;
+                }
+                if (types.includes('administrative_area_level_1')) {
+                    province = component.long_name;
+                }
+                if (types.includes('postal_code')) {
+                    postalCode = component.short_name;
+                }
+                if (types.includes('country')) {
+                    country = component.long_name;
+                }
+            }
+
+            var fullAddress = streetNumber && route ? streetNumber + ' ' + route : route;
+            $('#address').val(fullAddress);
+            $('#city').val(city);
+            $('#state').val(province).trigger('change');
+            $('#zip').val(postalCode);
+            $('#country').val(country);
+
+            updateLeadSource();
+        });
+    }
+</script>


### PR DESCRIPTION
## Summary
- extend the Add Lead modal to support Google Maps address autocomplete
- automate Lead Source selection from province/city

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a585fd6748332bd95d0ba4b815175