### PR TITLE
Fix lead modal address autocomplete

### DIFF
--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -12,7 +12,7 @@
 <?php echo form_close(); ?>
 
 <!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initAutocomplete" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initLeadModalAutocomplete" async defer></script>
 
 <script type="text/javascript">
     $(document).ready(function () {
@@ -97,7 +97,7 @@
     }
 
     // Google Places Autocomplete Initialization
-    function initAutocomplete() {
+    function initLeadModalAutocomplete() {
         var addressInput = document.getElementById('address');
         var autocomplete = new google.maps.places.Autocomplete(addressInput, {
             types: ['address'],


### PR DESCRIPTION
## Summary
- update the Google Maps callback to use a unique function name
- rename the JS initializer to avoid name collisions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a632692148332a0653bd16f472667