### PR TITLE
Fix address autocomplete on lead modal

### DIFF
--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -12,8 +12,6 @@
 <?php echo form_close(); ?>
 
 <!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initLeadModalAutocomplete" async defer></script>
-
 <script type="text/javascript">
     $(document).ready(function () {
         $("#lead-form").appForm({
@@ -43,7 +41,22 @@
 
         // Dynamic logic: override lead source based on location
         $("#state, #city").on("change keyup", updateLeadSource);
+
+        loadMapsScript(initLeadModalAutocomplete);
     });
+
+    function loadMapsScript(callback) {
+        if (window.google && google.maps && google.maps.places) {
+            callback();
+            return;
+        }
+        var script = document.createElement('script');
+        script.src = "https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places";
+        script.async = true;
+        script.defer = true;
+        script.onload = callback;
+        document.head.appendChild(script);
+    }
 
     function updateLeadSource() {
         var cityVal = $("#city").val().trim().toLowerCase();


### PR DESCRIPTION
## Summary
- ensure Google Places API loads correctly when opening the lead modal
- call `initLeadModalAutocomplete` after loading Maps script

## Testing
- `php -l app/Views/leads/modal_form.php`

------
https://chatgpt.com/codex/tasks/task_e_687a654ff4c48332aec42c90ae635c76