### PR TITLE
Fix address autocomplete in lead modal

### DIFF
--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -12,7 +12,6 @@
 <?php echo form_close(); ?>
 
 <!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initLeadModalAutocomplete" async defer></script>
 <script type="text/javascript">
     $(document).ready(function () {
         $("#lead-form").appForm({
@@ -160,3 +159,5 @@
         });
     }
 </script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initLeadModalAutocomplete" async defer></script>
+


### PR DESCRIPTION
## Summary
- ensure the Google Places script loads after the autocomplete function is defined

## Testing
- `php -l app/Views/leads/modal_form.php`


------
https://chatgpt.com/codex/tasks/task_e_687a6f1bb1d48332bc8dbdf52c55d17b