### PR TITLE
Fix lead modal autocomplete

### DIFF
--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -42,11 +42,21 @@
         // Dynamic logic: override lead source based on location
         $("#state, #city").on("change keyup", updateLeadSource);
 
-        if (window.google && google.maps && google.maps.places) {
-            initLeadModalAutocomplete();
-        }
+        loadMapsScript(initLeadModalAutocomplete);
     });
 
+    function loadMapsScript(callback) {
+        if (window.google && google.maps && google.maps.places) {
+            callback();
+            return;
+        }
+        var script = document.createElement('script');
+        script.src = "https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places";
+        script.async = true;
+        script.defer = true;
+        script.onload = callback;
+        document.head.appendChild(script);
+    }
     function updateLeadSource() {
         var cityVal = $("#city").val().trim().toLowerCase();
         var provinceVal = $("#state").val();
@@ -159,5 +169,5 @@
         });
     }
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCN7FS848BKLuWUjFlV6c7NKxDlcebCL_g&libraries=places&callback=initLeadModalAutocomplete" async defer></script>
+
 


### PR DESCRIPTION
## Summary
- ensure Google Maps API loads in the lead modal

## Testing
- `php -l app/Views/leads/modal_form.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a71ae143c83328e86f60c51e004ab