### PR TITLE
Fix lead form autofocus issue

### DIFF
--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -41,7 +41,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));
@@ -61,7 +60,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));


### PR DESCRIPTION
## Summary
- remove unnecessary `autofocus` attributes from the lead form

## Testing
- `php -l app/Views/leads/lead_form_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_687a74484b54833289aa6ede9a707a92