### PR TITLE
Fix lead modal address autocomplete

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -109,6 +109,19 @@ $(document).ready(function () {
 
                 $("#ajaxModalContent").html(response);
 
+                // Execute inline scripts from the loaded modal content
+                var $modalScripts = $("#ajaxModalContent").find("script");
+                $modalScripts.each(function () {
+                    if (this.src) {
+                        var scriptTag = document.createElement("script");
+                        scriptTag.src = this.src;
+                        document.head.appendChild(scriptTag);
+                    } else {
+                        $.globalEval(this.innerHTML);
+                    }
+                });
+                $modalScripts.remove();
+
                 initAllNotEmptyWYSIWYGEditors(true, $("#ajaxModalContent"));
                 setModalScrollbar();
 


### PR DESCRIPTION
## Summary
- run inline scripts after loading modal content so Add Lead form initializes autocomplete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7cdc606c8332afd9c6a90218d828