### PR TITLE
Add date filter and summary chart

### DIFF
--- a/app/Views/clients/estimates/estimate_requests.php
+++ b/app/Views/clients/estimates/estimate_requests.php
@@ -24,6 +24,7 @@
         $("#estimate-request-table").appTable({
             source: '<?php echo_uri("estimate_requests/estimate_requests_list_data_of_client/" . $client_id) ?>',
             order: [[0, 'desc']],
+            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: [
                 {title: "<?php echo app_lang('id'); ?>", "class": "all"},
                 {visible: false, searchable: false},

--- a/app/Views/estimate_requests/estimate_forms.php
+++ b/app/Views/estimate_requests/estimate_forms.php
@@ -22,6 +22,7 @@
                 {title: "<?php echo app_lang("title"); ?>", "class": "all"},
                 {title: "<?php echo app_lang("public"); ?>", "class": "w150"},
                 {title: "<?php echo app_lang("embed"); ?>", "class": "option w150"},
+                {title: "<?php echo app_lang('summary'); ?>", "class": "w100"},
                 {title: "<?php echo app_lang("status"); ?>", "class": "w150"},
                 {title: '<i data-feather="menu" class="icon-16"></i>', "class": "text-center option w100"}
             ]

--- a/app/Views/estimate_requests/form_summary.php
+++ b/app/Views/estimate_requests/form_summary.php
@@ -1,0 +1,31 @@
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="page-title clearfix">
+            <h1><?php echo app_lang('estimate_request_summary'); ?></h1>
+        </div>
+        <div class="card-body">
+            <canvas id="summary-chart" height="300"></canvas>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        new Chart(document.getElementById('summary-chart'), {
+            type: 'bar',
+            data: {
+                labels: <?php echo $labels; ?>,
+                datasets: [{
+                    data: <?php echo $data; ?>,
+                    backgroundColor: '#6b8de3'
+                }]
+            },
+            options: {
+                responsive: true,
+                legend: {display: false},
+                scales: {
+                    yAxes: [{ticks: {beginAtZero: true}}]
+                }
+            }
+        });
+    });
+</script>

--- a/app/Views/estimate_requests/index.php
+++ b/app/Views/estimate_requests/index.php
@@ -26,6 +26,7 @@
                 {name: "status", class: "w150", options: <?php echo $statuses_dropdown; ?>},
                 {name: "form_id", class: "w150", options: <?php echo $forms_dropdown; ?>}
             ],
+            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: [
                 {title: "<?php echo app_lang('id'); ?>", "class": "all"},
                 {title: "<?php echo app_lang('client'); ?>", "class": "all"},

--- a/app/Views/leads/estimates/estimate_requests.php
+++ b/app/Views/leads/estimates/estimate_requests.php
@@ -23,6 +23,7 @@
         $("#estimate-request-table").appTable({
             source: '<?php echo_uri("estimate_requests/estimate_requests_list_data_of_client/" . $client_id) ?>',
             order: [[0, 'desc']],
+            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: [
                 {title: "<?php echo app_lang('id'); ?>"},
                 {visible: false, searchable: false},


### PR DESCRIPTION
## Summary
- allow filtering estimate requests by created date
- show summary chart of key form fields
- include date filter on client/lead estimate request lists
- add summary link in estimate form list

## Testing
- `php -l app/Controllers/Estimate_requests.php`
- `php -l app/Models/Estimate_requests_model.php`
- `php -l app/Views/estimate_requests/index.php`
- `php -l app/Views/estimate_requests/estimate_forms.php`
- `php -l app/Views/leads/estimates/estimate_requests.php`
- `php -l app/Views/clients/estimates/estimate_requests.php`
- `php -l app/Views/estimate_requests/form_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_687a908354a88332838b97210b201988