### PR TITLE
Restrict summary view and add pdf export

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -427,7 +427,10 @@ private function _make_estimate_request_row($data) {
             $embedded_code = modal_anchor(get_uri("estimate_requests/embedded_code_modal_form"), "<i data-feather='code' class='icon-16'></i>", array("title" => app_lang('embed'), "class" => "edit", "data-post-id" => $data->id));
         }
 
-        $summary = anchor(get_uri("estimate_requests/form_summary/" . $data->id), "<i data-feather='bar-chart-2' class='icon-16'></i>", array("title" => app_lang('estimate_request_summary')));
+        $summary = "-";
+        if ($data->id == 6) {
+            $summary = anchor(get_uri("estimate_requests/form_summary/" . $data->id), "<i data-feather='bar-chart-2' class='icon-16'></i>", array("title" => app_lang('estimate_request_summary')));
+        }
 
         return array(
             $title,

--- a/app/Views/estimate_requests/form_summary.php
+++ b/app/Views/estimate_requests/form_summary.php
@@ -4,10 +4,17 @@
             <h1><?php echo app_lang('estimate_request_summary'); ?></h1>
         </div>
         <div class="card-body">
-            <canvas id="summary-chart" height="300"></canvas>
+            <div class="text-end mb-3">
+                <button id="download-summary-pdf" class="btn btn-default">
+                    <i data-feather="download" class="icon-16"></i> <?php echo app_lang('download_pdf'); ?>
+                </button>
+            </div>
+            <canvas id="summary-chart" height="200"></canvas>
         </div>
     </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function () {
         new Chart(document.getElementById('summary-chart'), {
@@ -26,6 +33,17 @@
                     yAxes: [{ticks: {beginAtZero: true}}]
                 }
             }
+        });
+
+        document.getElementById('download-summary-pdf').addEventListener('click', function () {
+            html2canvas(document.getElementById('summary-chart')).then(function (canvas) {
+                var imgData = canvas.toDataURL('image/png');
+                var pdf = new jspdf.jsPDF();
+                var width = pdf.internal.pageSize.getWidth();
+                var height = canvas.height * width / canvas.width;
+                pdf.addImage(imgData, 'PNG', 0, 0, width, height);
+                pdf.save('summary.pdf');
+            });
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- only show summary link for estimate form 6
- add a smaller summary chart with a PDF export option

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a9407b320833296c0d07edbbc7af2