### PR TITLE
Add form title and counts to summary PDF

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -838,6 +838,8 @@ private function _make_estimate_request_row($data) {
 
         $summary = $this->Estimate_requests_model->get_custom_field_summary($form_id);
 
+        $form_info = $this->Estimate_forms_model->get_one($form_id);
+
         $labels = [
             'Switch from Will Call to Automatic Delivery with Monitor',
             'Switch from Cheque/Cash payment per Delivery to Equal Monthly Budget Autopay',
@@ -856,6 +858,9 @@ private function _make_estimate_request_row($data) {
 
         $view_data['labels'] = json_encode($labels);
         $view_data['data'] = json_encode($data);
+        $view_data['labels_array'] = $labels;
+        $view_data['data_array'] = $data;
+        $view_data['form_title'] = $form_info->title ?? '';
         return $this->template->rander('estimate_requests/form_summary', $view_data);
     }
 }

--- a/app/Views/estimate_requests/form_summary.php
+++ b/app/Views/estimate_requests/form_summary.php
@@ -2,14 +2,28 @@
     <div class="card">
         <div class="page-title clearfix">
             <h1><?php echo app_lang('estimate_request_summary'); ?></h1>
+            <?php if (!empty($form_title)) { ?>
+                <h4 class="mt-2"><?php echo $form_title; ?></h4>
+            <?php } ?>
         </div>
-        <div class="card-body">
+        <div class="card-body" id="summary-section">
             <div class="text-end mb-3">
                 <button id="download-summary-pdf" class="btn btn-default">
                     <i data-feather="download" class="icon-16"></i> <?php echo app_lang('download_pdf'); ?>
                 </button>
             </div>
-            <canvas id="summary-chart" height="200"></canvas>
+            <div class="row">
+                <div class="col-md-3">
+                    <ul class="list-unstyled">
+                        <?php foreach ($labels_array as $index => $label) { ?>
+                            <li><strong><?php echo $data_array[$index]; ?></strong> - <?php echo $label; ?></li>
+                        <?php } ?>
+                    </ul>
+                </div>
+                <div class="col-md-9">
+                    <canvas id="summary-chart" height="150"></canvas>
+                </div>
+            </div>
         </div>
     </div>
 </div>
@@ -36,7 +50,7 @@
         });
 
         document.getElementById('download-summary-pdf').addEventListener('click', function () {
-            html2canvas(document.getElementById('summary-chart')).then(function (canvas) {
+            html2canvas(document.getElementById('summary-section')).then(function (canvas) {
                 var imgData = canvas.toDataURL('image/png');
                 var pdf = new jspdf.jsPDF();
                 var width = pdf.internal.pageSize.getWidth();


### PR DESCRIPTION
## Summary
- show the selected form title on the summary page
- display counts for each answer beside the chart and shrink chart height
- include the entire summary section when exporting the PDF

## Testing
- `php -l app/Controllers/Estimate_requests.php`
- `php -l app/Views/estimate_requests/form_summary.php`

------
https://chatgpt.com/codex/tasks/task_e_687a95f2457483329a503534c9e62881