### PR TITLE
Add filterable client dashboard graphs

### DIFF
--- a/app/Helpers/widget_helper.php
+++ b/app/Helpers/widget_helper.php
@@ -1163,12 +1163,12 @@ if (!function_exists('total_contacts_widget')) {
 
 if (!function_exists('client_dashboard_summary_widget')) {
 
-    function client_dashboard_summary_widget() {
+    function client_dashboard_summary_widget($owner_id = 0, $return_as_data = false) {
         $Clients_model = model("App\Models\Clients_model");
-        $view_data["summary"] = $Clients_model->get_dashboard_summary();
+        $view_data["summary"] = $Clients_model->get_dashboard_summary(array("owner_id" => $owner_id));
 
         $template = new Template();
-        return $template->view("clients/widgets/client_dashboard_summary_widget", $view_data);
+        return $template->view("clients/widgets/client_dashboard_summary_widget", $view_data, $return_as_data);
     }
 }
 

--- a/app/Views/clients/overview/index.php
+++ b/app/Views/clients/overview/index.php
@@ -65,12 +65,36 @@
     </div>
 
     <div class="row mt20">
+        <div class="col-md-3 mb15">
+            <select id="dashboard-owner-filter" class="w-100" data-placeholder="<?php echo app_lang('owner'); ?>"></select>
+        </div>
+    </div>
+    <div id="client-dashboard-summary-container">
         <?php echo client_dashboard_summary_widget(); ?>
     </div>
 </div>
 
 <script type="text/javascript">
     $(document).ready(function () {
+        $("#dashboard-owner-filter").select2({data: <?php echo $owners_dropdown; ?>}).on("change", function () {
+            loadDashboardSummary($(this).val());
+        });
+        loadDashboardSummary("");
+
+        function loadDashboardSummary(ownerId) {
+            $.ajax({
+                url: "<?php echo get_uri('clients/load_client_dashboard_summary'); ?>",
+                type: 'POST',
+                data: {owner_id: ownerId},
+                dataType: 'json',
+                success: function (result) {
+                    if (result.success) {
+                        $("#client-dashboard-summary-container").html(result.statistics);
+                        if (window.feather) { feather.replace(); }
+                    }
+                }
+            });
+        }
         //trigger clients tab when it's client overview page
         $('body').on('click', '.client-widget-link', function (e) {
             e.preventDefault();

--- a/app/Views/clients/widgets/client_dashboard_summary_widget.php
+++ b/app/Views/clients/widgets/client_dashboard_summary_widget.php
@@ -8,6 +8,13 @@
                 <div class="widget-details">
                     <h1><?php echo number_format($summary->total_clients); ?></h1>
                     <span class="bg-transparent-white"><?php echo app_lang('total_clients'); ?></span>
+                    <div class="mt5">
+                        <span class="<?php echo $summary->trend->clients_percent >= 0 ? 'text-success' : 'text-danger'; ?>">
+                            <i data-feather="<?php echo $summary->trend->clients_percent >= 0 ? 'trending-up' : 'trending-down'; ?>" class="icon-14"></i>
+                            <?php echo round($summary->trend->clients_percent); ?>%
+                        </span>
+                    </div>
+                    <canvas id="client-count-chart" height="30"></canvas>
                 </div>
             </div>
         </div>
@@ -21,6 +28,13 @@
                 <div class="widget-details">
                     <h1><?php echo number_format($summary->total_volume, 2); ?></h1>
                     <span class="bg-transparent-white">Total Volume</span>
+                    <div class="mt5">
+                        <span class="<?php echo $summary->trend->volume_percent >= 0 ? 'text-success' : 'text-danger'; ?>">
+                            <i data-feather="<?php echo $summary->trend->volume_percent >= 0 ? 'trending-up' : 'trending-down'; ?>" class="icon-14"></i>
+                            <?php echo round($summary->trend->volume_percent); ?>%
+                        </span>
+                    </div>
+                    <canvas id="client-volume-chart" height="30"></canvas>
                 </div>
             </div>
         </div>
@@ -34,6 +48,13 @@
                 <div class="widget-details">
                     <h1><?php echo to_currency($summary->potential_margin); ?></h1>
                     <span class="bg-transparent-white">Potential Margin</span>
+                    <div class="mt5">
+                        <span class="<?php echo $summary->trend->margin_percent >= 0 ? 'text-success' : 'text-danger'; ?>">
+                            <i data-feather="<?php echo $summary->trend->margin_percent >= 0 ? 'trending-up' : 'trending-down'; ?>" class="icon-14"></i>
+                            <?php echo round($summary->trend->margin_percent); ?>%
+                        </span>
+                    </div>
+                    <canvas id="client-margin-chart" height="30"></canvas>
                 </div>
             </div>
         </div>
@@ -47,8 +68,41 @@
                 <div class="widget-details">
                     <h1><?php echo to_currency($summary->weighted_forecast); ?></h1>
                     <span class="bg-transparent-white">Weighted Forecast</span>
+                    <div class="mt5">
+                        <span class="<?php echo $summary->trend->forecast_percent >= 0 ? 'text-success' : 'text-danger'; ?>">
+                            <i data-feather="<?php echo $summary->trend->forecast_percent >= 0 ? 'trending-up' : 'trending-down'; ?>" class="icon-14"></i>
+                            <?php echo round($summary->trend->forecast_percent); ?>%
+                        </span>
+                    </div>
+                    <canvas id="client-forecast-chart" height="30"></canvas>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function () {
+        var labels = <?php echo json_encode($summary->months); ?>;
+        new Chart(document.getElementById('client-count-chart'), {
+            type: 'line',
+            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_clients); ?>, borderColor: '#2196f3', backgroundColor: 'rgba(33,150,243,0.1)', borderWidth: 1, pointRadius: 0}]},
+            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
+        });
+        new Chart(document.getElementById('client-volume-chart'), {
+            type: 'line',
+            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_volume); ?>, borderColor: '#17a2b8', backgroundColor: 'rgba(23,162,184,0.1)', borderWidth: 1, pointRadius: 0}]},
+            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
+        });
+        new Chart(document.getElementById('client-margin-chart'), {
+            type: 'line',
+            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_margin); ?>, borderColor: '#28a745', backgroundColor: 'rgba(40,167,69,0.1)', borderWidth: 1, pointRadius: 0}]},
+            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
+        });
+        new Chart(document.getElementById('client-forecast-chart'), {
+            type: 'line',
+            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_forecast); ?>, borderColor: '#ff7043', backgroundColor: 'rgba(255,112,67,0.1)', borderWidth: 1, pointRadius: 0}]},
+            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- extend `Clients_model::get_dashboard_summary` to support owner filtering and trend data
- update `client_dashboard_summary_widget` for dynamic charts
- add owner dropdown filter and AJAX loader in client overview
- expose dropdown data and AJAX endpoint in `Clients` controller

## Testing
- `php -l app/Models/Clients_model.php`


------
https://chatgpt.com/codex/tasks/task_e_687ab85daf008332bc15be53e78a0350