### PR TITLE
Fix client dashboard and expose source filters

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -276,7 +276,8 @@ class Leads extends Security_Controller {
             $data->primary_contact ? $primary_contact : "",
             $phone,
             $owner,
-        
+            $data->lead_source_title ? $data->lead_source_title : "-",
+
             $data->created_date,
             format_to_date($data->created_date, false)
         );

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -42,6 +42,7 @@
               {title: "Created Date", order_by: "created_date"},
             {title: "<?php echo app_lang('client_groups') ?>", order_by: "client_groups"},
             {title: "<?php echo app_lang('owner') ?>", order_by: "client_owner"},
+            {title: "<?php echo app_lang('source') ?>", order_by: "lead_source_title"},
             {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('total_invoiced') ?>", "class": "text-right"},
             {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('payment_received') ?>", "class": "text-right"},
             {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('due') ?>", "class": "text-right"},
@@ -77,6 +78,7 @@
                 {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
                 {name: "account_type", class: "w200", options: type_dropdown},
                 {name: "status", class: "w200", options: <?php echo view("clients/client_statuses"); ?>},
+                {name: "source_id", class: "w200", options: <?php echo view("leads/lead_sources", array("lead_sources" => $lead_sources)); ?>},
                 <?php echo $custom_field_filters; ?>
             ],
             rangeDatepicker: [
@@ -84,8 +86,8 @@
                 {startDate: {name: "estimated_close_start_date", value: ""}, endDate: {name: "estimated_close_end_date", value: ""}, label: "Estimated Close", showClearButton: true}
             ],
             columns: columns,
-            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),
-            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], '<?php echo $custom_field_headers; ?>'),
+            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], '<?php echo $custom_field_headers; ?>'),
+            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], '<?php echo $custom_field_headers; ?>'),
             ajax: {
                 dataSrc: function (data) {
                     console.log('Table Data:', data);

--- a/app/Views/clients/widgets/client_dashboard_summary_widget.php
+++ b/app/Views/clients/widgets/client_dashboard_summary_widget.php
@@ -14,7 +14,7 @@
                             <?php echo round($summary->trend->clients_percent); ?>%
                         </span>
                     </div>
-                    <canvas id="client-count-chart" height="30"></canvas>
+                    <!-- removed chart canvas -->
                 </div>
             </div>
         </div>
@@ -34,7 +34,7 @@
                             <?php echo round($summary->trend->volume_percent); ?>%
                         </span>
                     </div>
-                    <canvas id="client-volume-chart" height="30"></canvas>
+                    <!-- removed chart canvas -->
                 </div>
             </div>
         </div>
@@ -54,7 +54,7 @@
                             <?php echo round($summary->trend->margin_percent); ?>%
                         </span>
                     </div>
-                    <canvas id="client-margin-chart" height="30"></canvas>
+                    <!-- removed chart canvas -->
                 </div>
             </div>
         </div>
@@ -74,35 +74,11 @@
                             <?php echo round($summary->trend->forecast_percent); ?>%
                         </span>
                     </div>
-                    <canvas id="client-forecast-chart" height="30"></canvas>
+                    <!-- removed chart canvas -->
                 </div>
             </div>
         </div>
     </div>
 </div>
 
-<script>
-    $(document).ready(function () {
-        var labels = <?php echo json_encode($summary->months); ?>;
-        new Chart(document.getElementById('client-count-chart'), {
-            type: 'line',
-            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_clients); ?>, borderColor: '#2196f3', backgroundColor: 'rgba(33,150,243,0.1)', borderWidth: 1, pointRadius: 0}]},
-            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
-        });
-        new Chart(document.getElementById('client-volume-chart'), {
-            type: 'line',
-            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_volume); ?>, borderColor: '#17a2b8', backgroundColor: 'rgba(23,162,184,0.1)', borderWidth: 1, pointRadius: 0}]},
-            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
-        });
-        new Chart(document.getElementById('client-margin-chart'), {
-            type: 'line',
-            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_margin); ?>, borderColor: '#28a745', backgroundColor: 'rgba(40,167,69,0.1)', borderWidth: 1, pointRadius: 0}]},
-            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
-        });
-        new Chart(document.getElementById('client-forecast-chart'), {
-            type: 'line',
-            data: {labels: labels, datasets: [{data: <?php echo json_encode($summary->monthly_forecast); ?>, borderColor: '#ff7043', backgroundColor: 'rgba(255,112,67,0.1)', borderWidth: 1, pointRadius: 0}]},
-            options: {responsive: true, maintainAspectRatio: false, legend: {display: false}, scales:{xAxes:[{display:false}], yAxes:[{display:false}]}}
-        });
-    });
-</script>
+<!-- removed chart scripts -->

--- a/app/Views/leads/index.php
+++ b/app/Views/leads/index.php
@@ -44,7 +44,8 @@
             {title: "<?php echo app_lang("primary_contact") ?>", order_by: "primary_contact"},
             {title: "<?php echo app_lang("phone") ?>"},
             {title: "<?php echo app_lang("owner") ?>", order_by: "owner_name"},
-        
+            {title: "<?php echo app_lang('source') ?>", order_by: "lead_source_title"},
+
             {visible: false, searchable: false, order_by: "created_date"},
             {title: "<?php echo app_lang("created_date") ?>", "iDataSort": 5, order_by: "created_date"},
             {title: "<?php echo app_lang("status") ?>", order_by: "status"}
@@ -63,8 +64,8 @@
             <?php echo $custom_field_filters; ?>
             ],
             rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
-            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 6, 7], '<?php echo $custom_field_headers; ?>'),
-            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 6, 7], '<?php echo $custom_field_headers; ?>')
+            printColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 7, 8], '<?php echo $custom_field_headers; ?>'),
+            xlsColumns: combineCustomFieldsColumns([0, 1, 2, 3, 4, 5, 7, 8], '<?php echo $custom_field_headers; ?>')
     });
     }
     );


### PR DESCRIPTION
## Summary
- remove client overview chart that was broken
- show lead source in leads and clients tables
- allow filtering by lead source on clients list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687abf1002f48332b290be1b35edd84b