### PR TITLE
Expose lead source on clients and tidy overview

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -91,6 +91,8 @@ class Clients extends Security_Controller {
         $view_data['label_suggestions'] = $this->make_labels_dropdown("client", $view_data['model_info']->labels);
         $view_data["custom_fields"] = $this->Custom_fields_model->get_combined_details("clients", $client_id, $this->login_user->is_admin, $this->login_user->user_type)->getResult();
         $view_data['statuses'] = $this->Lead_status_model->get_details()->getResult(); // Add statuses for dropdown
+        $view_data['lead_sources'] = $this->Lead_source_model->get_details()->getResult();
+        $view_data['sources_dropdown'] = json_encode($this->_get_sources_dropdown());
 
         return $this->template->view('clients/modal_form', $view_data);
     }
@@ -108,19 +110,20 @@ class Clients extends Security_Controller {
 
     $company_name = $this->request->getPost('company_name');
 
-    $data = array(
-        "company_name" => $company_name,
-        "type" => $this->request->getPost('account_type'),
-        "address" => $this->request->getPost('address'),
-        "city" => $this->request->getPost('city'),
-        "state" => $this->request->getPost('state'),
-        "zip" => $this->request->getPost('zip'),
-        "country" => $this->request->getPost('country'),
-        "phone" => $this->request->getPost('phone'),
-        "website" => $this->request->getPost('website'),
-        "vat_number" => $this->request->getPost('vat_number'),
-        "gst_number" => $this->request->getPost('gst_number')
-    );
+        $data = array(
+            "company_name" => $company_name,
+            "type" => $this->request->getPost('account_type'),
+            "address" => $this->request->getPost('address'),
+            "city" => $this->request->getPost('city'),
+            "state" => $this->request->getPost('state'),
+            "zip" => $this->request->getPost('zip'),
+            "country" => $this->request->getPost('country'),
+            "phone" => $this->request->getPost('phone'),
+            "website" => $this->request->getPost('website'),
+            "vat_number" => $this->request->getPost('vat_number'),
+            "gst_number" => $this->request->getPost('gst_number'),
+            "lead_source_id" => $this->request->getPost('lead_source_id')
+        );
 
     if ($this->login_user->user_type === "staff") {
         $group_ids = $this->request->getPost('group_ids');

--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -98,6 +98,23 @@
 
 <div class="form-group">
     <div class="row">
+        <label for="lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
+        <div class="<?php echo $field_column; ?>">
+            <?php
+            echo form_input(array(
+                "id" => "lead_source_id",
+                "name" => "lead_source_id",
+                "value" => $model_info->lead_source_id,
+                "class" => "form-control",
+                "placeholder" => app_lang('source')
+            ));
+            ?>
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="row">
         <label for="address" class="<?php echo $label_column; ?>"><?php echo app_lang('address'); ?></label>
         <div class="<?php echo $field_column; ?>">
             <?php
@@ -348,6 +365,12 @@
             $("#group_ids").select2({
                 multiple: true,
                 data: <?php echo json_encode($groups_dropdown); ?>
+            });
+        <?php } ?>
+
+        <?php if (isset($sources_dropdown)) { ?>
+            $('#lead_source_id').select2({
+                data: <?php echo $sources_dropdown; ?>
             });
         <?php } ?>
 

--- a/app/Views/clients/overview/index.php
+++ b/app/Views/clients/overview/index.php
@@ -64,42 +64,12 @@
         </div>
     </div>
 
-    <div class="row mt20">
-        <div class="col-md-3 mb15">
-            <select id="dashboard-owner-filter" class="w-100" data-placeholder="<?php echo app_lang('owner'); ?>"></select>
-        </div>
-    </div>
-    <div id="client-dashboard-summary-container">
-        <?php echo client_dashboard_summary_widget(); ?>
-    </div>
+    <!-- Dashboard summary removed -->
 </div>
 
 <script type="text/javascript">
     $(document).ready(function () {
-        $("#dashboard-owner-filter").select2({data: <?php echo $owners_dropdown; ?>});
-
-        //reload stats on owner change
-        $(document).on("change", "#dashboard-owner-filter", function () {
-            loadDashboardSummary($(this).val());
-        });
-
-        //initial load
-        loadDashboardSummary("");
-
-        function loadDashboardSummary(ownerId) {
-            $.ajax({
-                url: "<?php echo get_uri('clients/load_client_dashboard_summary'); ?>",
-                type: 'POST',
-                data: {owner_id: ownerId},
-                dataType: 'json',
-                success: function (result) {
-                    if (result.success) {
-                        $("#client-dashboard-summary-container").html(result.statistics);
-                        if (window.feather) { feather.replace(); }
-                    }
-                }
-            });
-        }
+        //dashboard summary script removed
         //trigger clients tab when it's client overview page
         $('body').on('click', '.client-widget-link', function (e) {
             e.preventDefault();


### PR DESCRIPTION
## Summary
- add lead source selection to client form
- save `lead_source_id` when editing clients
- pass lead source lists to modal form
- remove dashboard summary dropdown and KPI cards from clients overview

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Views/clients/overview/index.php`

------
https://chatgpt.com/codex/tasks/task_e_687ac3d9db5c83329a9a090e4a7b8e57