### PR TITLE
Remove client overview widgets

### DIFF
--- a/app/Views/clients/view.php
+++ b/app/Views/clients/view.php
@@ -48,9 +48,6 @@
                     <?php } ?>
                 </div>
 
-                <div>
-                    <?php echo view("clients/info_widgets/index"); ?>
-                </div>
 
                 <ul id="client-tabs" data-bs-toggle="ajax-tab" class="nav nav-tabs scrollable-tabs border-bottom-0" role="tablist">
                     <li><a role="presentation" data-bs-toggle="tab" href="<?php echo_uri("clients/contacts/" . $client_info->id); ?>" data-bs-target="#client-contacts"> <?php echo app_lang('contacts'); ?></a></li>

--- a/app/Views/dashboards/client_dashboard.php
+++ b/app/Views/dashboards/client_dashboard.php
@@ -2,17 +2,10 @@
 
 <div id="page-content" class="page-wrapper clearfix">
     <?php
-    if (count($dashboards) && !get_setting("disable_dashboard_customization_by_clients")) {
-        echo view("dashboards/dashboard_header");
-    }
-
     echo announcements_alert_widget();
 
     app_hooks()->do_action('app_hook_dashboard_announcement_extension');
     ?>
-    <div class="">
-        <?php echo view("clients/info_widgets/index"); ?>
-    </div>
 
     <?php if ($show_project_info) { ?>
         <div class="">


### PR DESCRIPTION
## Summary
- remove KPI widgets and dashboard dropdown from client dashboard
- drop outdated info widgets from client view page

## Testing
- `php -l app/Views/dashboards/client_dashboard.php`
- `php -l app/Views/clients/view.php`


------
https://chatgpt.com/codex/tasks/task_e_687e5ec15354833294ef73867c250b25