### PR TITLE
Fix lead source dropdown IDs

### DIFF
--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -98,9 +98,9 @@
 
 <div class="form-group">
     <div class="row">
-        <label for="lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
+        <label for="client_lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
         <div class="<?php echo $field_column; ?>">
-            <?php echo view('partials/lead_source_select', ['sources_dropdown' => $sources_dropdown, 'selected' => $model_info->lead_source_id]); ?>
+            <?php echo view('partials/lead_source_select', ['sources_dropdown' => $sources_dropdown, 'selected' => $model_info->lead_source_id, 'id' => 'client_lead_source_id']); ?>
         </div>
     </div>
 </div>

--- a/app/Views/leads/batch_update_modal_form.php
+++ b/app/Views/leads/batch_update_modal_form.php
@@ -59,11 +59,11 @@
                     echo form_checkbox("", "1", false, "class=' batch-update-checkbox form-check-input field-required'");
                     ?>
                 </div>
-                <label for="lead_source_id" class=" col-md-2 text-off"><?php echo app_lang('source'); ?></label>
+                <label for="batch_lead_source_id" class=" col-md-2 text-off"><?php echo app_lang('source'); ?></label>
                 <div class="col-md-9">
                     <?php
                     echo form_input(array(
-                        "id" => "lead_source_id",
+                        "id" => "batch_lead_source_id",
                         "name" => "lead_source_id",
                         "class" => "form-control",
                         "placeholder" => app_lang('source'),
@@ -162,7 +162,7 @@
             data: <?php echo json_encode($lead_statuses_dropdown); ?>
         });
 
-        $('#lead_source_id').select2({
+        $('#batch_lead_source_id').select2({
             data: <?php echo json_encode($sources_dropdown); ?>
         });
 

--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -104,9 +104,9 @@
 </div>
 <div class="form-group">
     <div class="row">
-        <label for="lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
+        <label for="lead_lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
         <div class="<?php echo $field_column; ?>">
-            <?php echo view('partials/lead_source_select', ['lead_sources' => $sources, 'selected' => $model_info->lead_source_id]); ?>
+            <?php echo view('partials/lead_source_select', ['lead_sources' => $sources, 'selected' => $model_info->lead_source_id, 'id' => 'lead_lead_source_id']); ?>
         </div>
     </div>
 </div>

--- a/app/Views/partials/lead_source_select.php
+++ b/app/Views/partials/lead_source_select.php
@@ -1,6 +1,7 @@
 <?php
 // Reusable lead source dropdown
 $selected = isset($selected) ? $selected : (isset($model_info) ? $model_info->lead_source_id : '');
+$id = isset($id) ? $id : 'lead_source_id';
 
 $dropdown_data = [];
 if (isset($sources_dropdown)) {
@@ -11,13 +12,13 @@ if (isset($sources_dropdown)) {
     }
 }
 ?>
-<select id="lead_source_id" name="lead_source_id" class="form-control select2"></select>
+<select id="<?php echo $id; ?>" name="lead_source_id" class="form-control select2"></select>
 <script>
     $(function(){
         var data = <?php echo json_encode($dropdown_data); ?>;
-        $('#lead_source_id').select2({data: data});
+        $('#<?php echo $id; ?>').select2({data: data});
         <?php if ($selected) { ?>
-        $('#lead_source_id').val('<?php echo $selected; ?>').trigger('change');
+        $('#<?php echo $id; ?>').val('<?php echo $selected; ?>').trigger('change');
         <?php } ?>
     });
 </script>


### PR DESCRIPTION
## Summary
- make `lead_source_select` partial accept a custom input id to avoid collisions
- update lead and client forms to pass unique ids
- update batch update modal to match new id

## Testing
- `php -l app/Views/partials/lead_source_select.php`
- `php -l app/Views/leads/lead_form_fields.php`
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Views/leads/batch_update_modal_form.php`


------
https://chatgpt.com/codex/tasks/task_e_687e64300f388332b890e97a0128c4aa