### PR TITLE
Add clients report view

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -95,6 +95,7 @@ if (!function_exists('get_reports_topbar')) {
 
         if (get_setting("module_lead") == "1" && ($ci->login_user->is_admin || $access_lead == "all")) {
             $reports_menu[] = array("name" => "leads", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
+            $reports_menu[] = array("name" => "clients", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Libraries/Left_menu.php
+++ b/app/Libraries/Left_menu.php
@@ -212,6 +212,7 @@ class Left_menu {
                     "expenses/summary",
                     "projects/team_members_summary",
                     "leads/converted_to_client_report",
+                    "clients/clients_report",
                     "tickets/tickets_chart_report"
                 )
             );

--- a/app/Views/clients/reports/client_summary.php
+++ b/app/Views/clients/reports/client_summary.php
@@ -1,0 +1,90 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="table-responsive">
+            <table id="clients-report-table" class="display" width="100%"></table>
+            <div id="clients-summary" class="p15"></div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        var showInvoiceInfo = <?php echo json_encode($show_invoice_info); ?>;
+        var showOptions = <?php echo json_encode($can_edit_clients); ?>;
+        var type_dropdown = [
+            {id: "", text: "- <?php echo app_lang('type'); ?> -"},
+            {id: "person", text: "<?php echo app_lang('person'); ?>"},
+            {id: "organization", text: "<?php echo app_lang('organization'); ?>"}
+        ];
+
+        var columns = [
+            {title: "<?php echo app_lang('id'); ?>", class: "text-center w50 desktop", order_by: "id"},
+            {title: "<?php echo app_lang('name'); ?>", class: "all", order_by: "company_name"},
+            {title: "<?php echo app_lang('type'); ?>", order_by: "account_type"},
+            {title: "Created Date", order_by: "created_date"},
+            {title: "<?php echo app_lang('client_groups'); ?>", order_by: "client_groups"},
+            {title: "<?php echo app_lang('owner'); ?>", order_by: "client_owner"},
+            {title: "<?php echo app_lang('source'); ?>", order_by: "lead_source_title"},
+            {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('total_invoiced'); ?>", class: "text-right"},
+            {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('payment_received'); ?>", class: "text-right"},
+            {visible: showInvoiceInfo, searchable: showInvoiceInfo, title: "<?php echo app_lang('due'); ?>", class: "text-right"},
+            {title: "<?php echo app_lang('status'); ?>", class: "text-center w100", order_by: "status"},
+            {title: "Probability %", class: "text-center w100"},
+            {title: "Potential Margin", class: "text-right w100"},
+            {title: "Weighted Forecast", class: "text-right w100"}
+        ];
+
+        <?php if (!empty($custom_field_headers)) { ?>
+        try {
+            var customColumns = [<?php echo $custom_field_headers; ?>];
+            columns = columns.concat(customColumns.filter(function (col) { return col && typeof col === 'object'; }));
+        } catch (e) { }
+        <?php } ?>
+
+        columns.push({title: '<i data-feather="menu" class="icon-16"></i>', class: "text-center option w100", visible: showOptions});
+
+        var updateSummary = function (info) {
+            if (!info) return;
+            var html = "<strong>Average Probability:</strong> " + parseFloat(info.avg_probability).toFixed(2) + "% ";
+            html += "&nbsp;&nbsp;<strong>Sum Potential Margin:</strong> " + toCurrency(info.sum_potential_margin);
+            html += "&nbsp;&nbsp;<strong>Sum Weighted Forecast:</strong> " + toCurrency(info.sum_weighted_forecast);
+            html += "&nbsp;&nbsp;<strong>Sum Volume:</strong> " + parseFloat(info.sum_volume).toFixed(2);
+            html += "&nbsp;&nbsp;<strong>Average Margin Above Rack:</strong> " + parseFloat(info.avg_margin_above_rack).toFixed(2);
+            $("#clients-summary").html(html);
+        };
+
+        var quick_filters_dropdown = <?php echo view("clients/quick_filters_dropdown"); ?>;
+        $("#clients-report-table").appTable({
+            source: '<?php echo_uri("clients/clients_report_list_data") ?>',
+            filterDropdown: [
+                {name: "quick_filter", class: "w200", options: quick_filters_dropdown},
+                <?php if ($login_user->is_admin || get_array_value($login_user->permissions, "client") === "all") { ?>
+                    {name: "owner_id", class: "w200", options: <?php echo $team_members_dropdown; ?>},
+                <?php } ?>
+                {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
+                {name: "account_type", class: "w200", options: type_dropdown},
+                {name: "status", class: "w200", options: <?php echo view("clients/client_statuses"); ?>},
+                {name: "source_id", class: "w200", options: <?php echo view("leads/lead_sources", array("lead_sources" => $lead_sources)); ?>},
+                <?php echo $custom_field_filters; ?>
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true},
+                {startDate: {name: "estimated_close_start_date", value: ""}, endDate: {name: "estimated_close_end_date", value: ""}, label: "Estimated Close", showClearButton: true}
+            ],
+            columns: columns,
+            printColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13], '<?php echo $custom_field_headers; ?>'),
+            xlsColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13], '<?php echo $custom_field_headers; ?>'),
+            onInitComplete: function (instance) {
+                updateSummary(instance.settings.summationInfo);
+            },
+            onRelaodCallback: function (instance) {
+                updateSummary(instance.settings.summationInfo);
+            },
+            footerCallback: function (row, data, start, end, display, table) {
+                updateSummary(table.settings()[0].oInit.summationInfo);
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add clients report view under Reports
- support table summarization and remove contact & phone columns
- expose endpoints for clients report data
- update reports menu and side menu

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Helpers/reports_helper.php`
- `php -l app/Libraries/Left_menu.php`
- `php -l app/Views/clients/reports/client_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_687e6d174f2483329df0faef74299d0b