### PR TITLE
Add totals row in client summary

### DIFF
--- a/app/Views/clients/reports/client_summary.php
+++ b/app/Views/clients/reports/client_summary.php
@@ -45,6 +45,15 @@
 
         columns.push({title: '<i data-feather="menu" class="icon-16"></i>', class: "text-center option w100", visible: showOptions});
 
+        //prepare summation options to show totals row and export summary
+        var summation = [
+            {column: 11, fieldName: "avg_probability", dataType: 'number'},
+            {column: 12, fieldName: "sum_potential_margin", dataType: 'currency', dynamicSymbol: true},
+            {column: 13, fieldName: "sum_weighted_forecast", dataType: 'currency', dynamicSymbol: true},
+            {column: 14, fieldName: "sum_volume", dataType: 'number'},
+            {column: 15, fieldName: "avg_margin_above_rack", dataType: 'number'}
+        ];
+
         var updateSummary = function (info) {
             if (!info) return;
             var html = "<strong>Average Probability:</strong> " + parseFloat(info.avg_probability).toFixed(2) + "% ";
@@ -76,6 +85,7 @@
             columns: columns,
             printColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13], '<?php echo $custom_field_headers; ?>'),
             xlsColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13], '<?php echo $custom_field_headers; ?>'),
+            summation: summation,
             onInitComplete: function (instance) {
                 var info = null;
                 if (instance && typeof instance.settings === "function") {
@@ -96,6 +106,28 @@
             },
             footerCallback: function (row, data, start, end, display, table) {
                 var dt = (table && typeof table.settings === "function") ? table : $(table).DataTable();
+                var api = dt.api();
+
+                //calculate page average for probability column
+                var probData = api.column(11, {page: 'current'}).data();
+                var probSum = 0;
+                probData.each(function(value) {
+                    var n = parseFloat(value);
+                    if (!isNaN(n)) { probSum += n; }
+                });
+                var avgProb = probData.length ? probSum / probData.length : 0;
+                $(dt.table().footer()).find('[data-current-page="11"]').html(avgProb.toFixed(2) + "%");
+
+                //calculate page average for margin above rack column
+                var marData = api.column(15, {page: 'current'}).data();
+                var marSum = 0;
+                marData.each(function(value) {
+                    var n = parseFloat(value);
+                    if (!isNaN(n)) { marSum += n; }
+                });
+                var avgMar = marData.length ? marSum / marData.length : 0;
+                $(dt.table().footer()).find('[data-current-page="15"]').html(avgMar.toFixed(2));
+
                 updateSummary(dt.settings()[0].oInit.summationInfo);
             }
         });


### PR DESCRIPTION
## Summary
- implement summation options to generate totals row
- compute page averages for probability and margin above rack

## Testing
- `php -l app/Views/clients/reports/client_summary.php`

------
https://chatgpt.com/codex/tasks/task_e_687e7c4f78f083329085edaf3e8bbc23