### PR TITLE
Fix DataTable API usage in client summary

### DIFF
--- a/app/Views/clients/reports/client_summary.php
+++ b/app/Views/clients/reports/client_summary.php
@@ -105,8 +105,8 @@
                 updateSummary(info);
             },
             footerCallback: function (row, data, start, end, display, table) {
-                var dt = (table && typeof table.settings === "function") ? table : $(table).DataTable();
-                var api = dt.api();
+                var api = new $.fn.dataTable.Api(table);
+                var dt = api;
 
                 //calculate page average for probability column
                 var probData = api.column(11, {page: 'current'}).data();


### PR DESCRIPTION
## Summary
- ensure DataTable API instance is created correctly for footer callback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e81c7211483328b8d699f3f71ede6