### PR TITLE
Update team member summary to use client stages

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1561,7 +1561,8 @@ class Leads extends Security_Controller {
             "created_date_from" => $this->request->getPost("created_date_from"),
             "created_date_to" => $this->request->getPost("created_date_to"),
             "source_id" => $this->request->getPost("source_id"),
-            "label_id" => $this->request->getPost("label_id")
+            "label_id" => $this->request->getPost("label_id"),
+            "is_lead" => 0
         );
 
         $list_data = $this->Clients_model->get_leads_team_members_summary($options)->getResult();
@@ -1594,11 +1595,22 @@ class Leads extends Security_Controller {
             $status_total_array[get_array_value($status_total, 0)] = get_array_value($status_total, 1);
         }
 
+        $won = 0;
+        $lost = 0;
+
         foreach ($lead_statuses as $status) {
             $total = get_array_value($status_total_array, $status->id);
             $row_data[] = $total ? $total : 0;
+
+            if ($status->id == 6) {
+                $won = $total ? $total : 0;
+            } else if ($status->id == 8) {
+                $lost = $total ? $total : 0;
+            }
         }
-        $row_data[] = $data->converted_to_client ? $data->converted_to_client : 0;
+
+        $percent = ($won + $lost) ? round(($won / ($won + $lost)) * 100, 2) : 0;
+        $row_data[] = $percent;
 
         return $row_data;
     }

--- a/app/Views/leads/reports/team_members_summary.php
+++ b/app/Views/leads/reports/team_members_summary.php
@@ -8,7 +8,10 @@ $columns = array(array("title" => app_lang("owner"), "class" => "all"));
 foreach ($lead_statuses as $status) {
     $columns[] = array("title" => $status->title, "class" => "text-right");
 }
-$columns[] = array("title" => app_lang("converted_to_client"), "class" => "text-right all");
+$columns[] = array("title" => "Won %", "class" => "text-right all");
+
+$total_columns = count($columns);
+$print_columns = range(0, $total_columns - 1);
 ?>
 
 <script type="text/javascript">
@@ -24,8 +27,8 @@ $columns[] = array("title" => app_lang("converted_to_client"), "class" => "text-
                 {name: "label_id", class: "w200", options: <?php echo $labels_dropdown; ?>}
             ],
             columns: <?php echo json_encode($columns) ?>,
-            printColumns: [0, 1, 2, 3, 4, 5, 6, 7],
-            xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7]
+            printColumns: <?php echo json_encode($print_columns); ?>,
+            xlsColumns: <?php echo json_encode($print_columns); ?>
         });
     }
     );


### PR DESCRIPTION
## Summary
- base team member stage counts on clients instead of leads
- show win percentage for each member

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/team_members_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_687e878b066483328457a20ee5284925