### PR TITLE
Enable date range filtering for converted client charts

### DIFF
--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -811,7 +811,7 @@ function get_details($options = array()) {
         $group_by = $this->_get_clean_value($options, "group_by");
 
         if ($group_by == "created_date") {
-            $sql = "SELECT DATE_FORMAT($clients_table.created_date,'%d') AS day, SUM(1) total_clients
+            $sql = "SELECT DATE($clients_table.created_date) AS date, SUM(1) total_clients
                 FROM $clients_table
                 WHERE $clients_table.is_lead=0 AND $clients_table.deleted=0 $where
                 GROUP BY DATE($clients_table.created_date)";

--- a/app/Views/leads/reports/converted_to_client.php
+++ b/app/Views/leads/reports/converted_to_client.php
@@ -35,10 +35,11 @@ $range_type_dropdown = json_encode(array(
 <script type="text/javascript">
 
     $(document).ready(function () {
+        var dynamicDates = getDynamicDates();
         $("#converted-to-client-monthly-chart-filters").appFilters({
             source: '<?php echo_uri("leads/converted_to_client_charts_data") ?>',
             targetSelector: '#load-converted-to-client-monthly-chart',
-            dateRangeType: "monthly",
+            rangeDatepicker: [{startDate: {name: "start_date", value: dynamicDates.start_of_month}, endDate: {name: "end_date", value: dynamicDates.end_of_month}, showClearButton: true, label: "<?php echo app_lang('date'); ?>", ranges: ['this_month', 'last_month', 'this_year', 'last_year', 'last_30_days', 'last_7_days']}],
             reloadSelector: "#converted-to-client-button",
             filterDropdown: [
                 {name: "owner_id", class: "w200", options: <?php echo $owners_dropdown; ?>},

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -53,7 +53,7 @@
                 tooltips: {
                     callbacks: {
                         title: function (tooltipItem, data) {
-                            return  data['labels'][tooltipItem[0]['index']] + " <?php echo app_lang($month) ?>";
+                            return  data['labels'][tooltipItem[0]['index']];
                         }
                     }
                 },


### PR DESCRIPTION
## Summary
- allow date range selection for converted client report charts
- return full date for client stats grouping
- support rendering day-wise data across date ranges

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Views/leads/reports/converted_to_client.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_687fac4342cc8332954b636f10366e86