### PR TITLE
Add close rate pie chart to reports

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1502,6 +1502,23 @@ class Leads extends Security_Controller {
             $client_status_colors[] = $status->color;
         }
 
+        //prepare close rate data using won and lost statuses
+        $lead_statuses = $this->Lead_status_model->get_details()->getResult();
+        list($won_status_id, $lost_status_id) = $this->_get_won_lost_status_ids($lead_statuses);
+        $won_total = 0;
+        $lost_total = 0;
+        foreach ($client_statistics as $status) {
+            if ($status->lead_status_id == $won_status_id) {
+                $won_total = $status->total * 1;
+            } else if ($status->lead_status_id == $lost_status_id) {
+                $lost_total = $status->total * 1;
+            }
+        }
+
+        $view_data["close_rate_labels"] = json_encode(array("Won", "Lost"));
+        $view_data["close_rate_data"] = json_encode(array($won_total, $lost_total));
+        $view_data["close_rate_colors"] = json_encode(array("#28a745", "#dc3545"));
+
         $view_data["client_status_labels"] = json_encode($client_status_labels);
         $view_data["client_status_data"] = json_encode($client_status_data);
         $view_data["client_status_colors"] = json_encode($client_status_colors);

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -1918,6 +1918,7 @@ $lang["select_from_template"] = "Select from template";
 $lang["type_new_item"] = "Type new item";
 
 $lang["conversion_rate"] = "Conversion rate";
+$lang["close_rate"] = "Close rate";
 
 $lang["all_tasks"] = "All objectives";
 $lang["user_roles"] = "User Roles";

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -1919,6 +1919,7 @@ $lang["select_from_template"] = "Select from template";
 $lang["type_new_item"] = "Type new item";
 
 $lang["conversion_rate"] = "Conversion rate";
+$lang["close_rate"] = "Close rate";
 
 $lang["all_tasks"] = "All tasks";
 $lang["user_roles"] = "User Roles";

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -28,6 +28,14 @@
                 </div>
             </div>
         </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mt20"><strong><?php echo app_lang("close_rate"); ?></strong></div>
+                <div class="mt20 pt10">
+                    <canvas id="clients-close-rate-chart" style="width:100%; height: 300px;"></canvas>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -211,6 +219,34 @@
                     {
                         data: <?php echo $client_status_data; ?>,
                         backgroundColor: <?php echo $client_status_colors; ?>,
+                        borderWidth: 0
+                    }]
+            },
+            options: {
+                cutoutPercentage: 0,
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: {
+                    display: true,
+                    position: 'bottom',
+                    labels: {
+                        fontColor: "#898fa9"
+                    }
+                },
+                animation: {
+                    animateScale: true
+                }
+            }
+        });
+
+        new Chart(document.getElementById("clients-close-rate-chart"), {
+            type: 'pie',
+            data: {
+                labels: <?php echo $close_rate_labels; ?>,
+                datasets: [
+                    {
+                        data: <?php echo $close_rate_data; ?>,
+                        backgroundColor: <?php echo $close_rate_colors; ?>,
                         borderWidth: 0
                     }]
             },


### PR DESCRIPTION
## Summary
- compute won vs lost totals and include close rate chart data
- show Close Rate pie chart on Converted to Client monthly report
- add translation string for `close_rate`

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`
- `php -l app/Language/english/default_lang.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_688808b7d90c833297237ccb2c0c34c1