### PR TITLE
Adjust report charts

### DIFF
--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -21,15 +21,13 @@
 
         </div>
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-6">
                 <div class="mt20"><strong><?php echo app_lang("client_status"); ?></strong></div>
                 <div class="mt20 pt10">
                     <canvas id="clients-status-wise-chart" style="width:100%; height: 300px;"></canvas>
                 </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-6">
                 <div class="mt20"><strong><?php echo app_lang("close_rate"); ?></strong></div>
                 <div class="mt20 pt10">
                     <canvas id="clients-close-rate-chart" style="width:100%; height: 300px;"></canvas>


### PR DESCRIPTION
## Summary
- keep the last two graphs side by side
- chart closed clients by custom field 272

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`

------
https://chatgpt.com/codex/tasks/task_e_68880cdf798c8332bd03f3aec2c06fd2