### PR TITLE
Fix leads report DB usage and adjust language

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1534,8 +1534,9 @@ class Leads extends Security_Controller {
         $start_date = get_array_value($options, "start_date");
         $end_date = get_array_value($options, "end_date");
 
-        $clients_table = $this->db->prefixTable('clients');
-        $cf_table = $this->db->prefixTable('custom_field_values');
+        $db = db_connect('default');
+        $clients_table = $db->prefixTable('clients');
+        $cf_table = $db->prefixTable('custom_field_values');
 
         $where = "";
         if ($start_date && $end_date) {
@@ -1557,7 +1558,7 @@ class Leads extends Security_Controller {
                 LEFT JOIN $cf_table AS cf ON cf.custom_field_id=272 AND cf.related_to_type='clients' AND cf.related_to_id=c.id AND cf.deleted=0
                 WHERE c.is_lead=0 AND c.deleted=0 $where
                 GROUP BY DATE(cf.value)";
-        $converted_result = $this->db->query($sql)->getResult();
+        $converted_result = $db->query($sql)->getResult();
 
         $start = strtotime($start_date);
         $end = strtotime($end_date);

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2348,7 +2348,7 @@ $lang["client_can_access_notes"] = "Opportunity can access notes?";
 $lang["my_tasks_overview"] = "My Objectives Overview";
 
 $lang["leads_overview"] = "Leads Overview";
-$lang["converted_to_client"] = "Converted to opportunity";
+$lang["converted_to_client"] = "Converted to client";
 
 $lang["remember_to_add_this_urls_in_authorized_redirect_uri"] = "Remember to add this urls in Authorized redirect uri";
 


### PR DESCRIPTION
## Summary
- correct the database connection in the `Leads` controller
- update English custom language string for "converted to client"

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_6888187b2d10833285c5de3ea5d1373b