### PR TITLE
Add custom field 275 to estimate request list and export

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -170,18 +170,19 @@ private function _make_estimate_request_row($data) {
         }
     }
 
-    // Fetch custom field values for IDs 246, 267, 268, 269, 270 and 271
-    $custom_field_246 = "";
-    $custom_field_267 = "";
-    $custom_field_268 = "";
-    $custom_field_269 = "";
-    $custom_field_270 = "";
-    $custom_field_271 = "";
-    $custom_field_values = $this->Custom_field_values_model->get_details(array(
-        "related_to_type" => "estimate_request",
-        "related_to_id" => $data->id,
-        "custom_field_id" => array(246, 267, 268, 269, 270, 271) // Fetch these IDs
-    ))->getResult();
+        // Fetch custom field values for IDs 246, 267, 268, 269, 270, 271 and 275
+        $custom_field_246 = "";
+        $custom_field_267 = "";
+        $custom_field_268 = "";
+        $custom_field_269 = "";
+        $custom_field_270 = "";
+        $custom_field_271 = "";
+        $custom_field_275 = "";
+        $custom_field_values = $this->Custom_field_values_model->get_details(array(
+            "related_to_type" => "estimate_request",
+            "related_to_id" => $data->id,
+            "custom_field_id" => array(246, 267, 268, 269, 270, 271, 275) // Fetch these IDs
+        ))->getResult();
 
     foreach ($custom_field_values as $field) {
         if ($field->custom_field_id == 246) {
@@ -196,6 +197,8 @@ private function _make_estimate_request_row($data) {
             $custom_field_270 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
         } elseif ($field->custom_field_id == 271) {
             $custom_field_271 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 275) {
+            $custom_field_275 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
         }
     }
 
@@ -235,6 +238,7 @@ private function _make_estimate_request_row($data) {
         $custom_field_269,
         $custom_field_270,
         $custom_field_271,
+        $custom_field_275,
         $assigned_to,
         $data->created_at,
         format_to_datetime($data->created_at),

--- a/app/Views/estimate_requests/index.php
+++ b/app/Views/estimate_requests/index.php
@@ -41,14 +41,15 @@
                 {title: "Bank Payment"},
                 {title: "e-Invoice"},
                 {title: "Additional Info"},
+                {title: "Custom 275"},
                 {title: "<?php echo app_lang('assigned_to'); ?>"},
                 {visible: false, searchable: false},
-                {title: '<?php echo app_lang("created_date") ?>', "iDataSort": 14},
+                {title: '<?php echo app_lang("created_date") ?>', "iDataSort": 15},
                 {title: "<?php echo app_lang('status'); ?>"},
                 {title: "<i data-feather='menu' class='icon-16'></i>", "class": "text-center dropdown-option w50"}
             ],
-            printColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16],
-            xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16]
+            printColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17],
+            xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17]
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- include custom field 275 when building estimate request rows
- show new "Custom 275" column on estimate request list
- export the new column in Excel/print views

## Testing
- `php -l app/Controllers/Estimate_requests.php`
- `php -l app/Views/estimate_requests/index.php`

------
https://chatgpt.com/codex/tasks/task_e_6888a679b330833295b1088c98caef87