### PR TITLE
Add margin and volume charts to client reports

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2098,6 +2098,40 @@ private function _save_a_row_of_excel_data($row_data) {
         echo json_encode($result);
     }
 
+    function clients_report_charts_data() {
+        $this->access_only_allowed_members();
+
+        $options = array(
+            "group_id" => $this->request->getPost("group_id"),
+            "account_type" => $this->request->getPost("account_type"),
+            "owner_id" => $this->request->getPost("owner_id"),
+            "source_id" => $this->request->getPost("source_id"),
+            "client_groups" => $this->allowed_client_groups,
+            "start_date" => $this->request->getPost("start_date"),
+            "end_date" => $this->request->getPost("end_date"),
+            "estimated_close_start_date" => $this->request->getPost("estimated_close_start_date"),
+            "estimated_close_end_date" => $this->request->getPost("estimated_close_end_date"),
+            "closed_start_date" => $this->request->getPost("closed_start_date"),
+            "closed_end_date" => $this->request->getPost("closed_end_date"),
+            "status_ids" => $this->request->getPost("status_id")
+        );
+
+        $rows = $this->Clients_model->get_potential_margin_volume_by_stage($options);
+
+        $labels = $margin = $volume = array();
+        foreach ($rows as $row) {
+            $labels[] = $row->status_title;
+            $margin[] = floatval($row->potential_margin);
+            $volume[] = floatval($row->volume);
+        }
+
+        $view_data["labels"] = json_encode($labels);
+        $view_data["margin_data"] = json_encode($margin);
+        $view_data["volume_data"] = json_encode($volume);
+
+        return $this->template->view("clients/reports/margin_volume_chart", $view_data);
+    }
+
     function load_client_dashboard_summary() {
         $this->access_only_allowed_members();
 

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -978,4 +978,85 @@ function get_details($options = array()) {
 
         return $summary;
     }
+
+    //get potential margin and volume grouped by lead status
+    function get_potential_margin_volume_by_stage($options = array()) {
+        $clients_table = $this->db->prefixTable('clients');
+        $cf_table = $this->db->prefixTable('custom_field_values');
+        $lead_status_table = $this->db->prefixTable('lead_status');
+
+        $where = "";
+
+        $owner_id = $this->_get_clean_value($options, "owner_id");
+        if ($owner_id) {
+            $where .= " AND $clients_table.owner_id=$owner_id";
+        }
+
+        $group_id = $this->_get_clean_value($options, "group_id");
+        if ($group_id) {
+            $where .= " AND FIND_IN_SET('$group_id', $clients_table.group_ids)";
+        }
+
+        $account_type = $this->_get_clean_value($options, "account_type");
+        if ($account_type) {
+            $where .= " AND $clients_table.type='$account_type'";
+        }
+
+        $source_id = $this->_get_clean_value($options, "source_id");
+        if ($source_id) {
+            $where .= " AND $clients_table.lead_source_id='$source_id'";
+        }
+
+        $status_ids = get_array_value($options, "status_ids");
+        if ($status_ids && is_array($status_ids)) {
+            $status_ids = array_map('intval', $status_ids);
+            $where .= " AND $clients_table.lead_status_id IN(" . implode(',', $status_ids) . ")";
+        }
+
+        $start_date = $this->_get_clean_value($options, "start_date");
+        if ($start_date) {
+            $where .= " AND DATE($clients_table.created_date)>='$start_date'";
+        }
+        $end_date = $this->_get_clean_value($options, "end_date");
+        if ($end_date) {
+            $where .= " AND DATE($clients_table.created_date)<='$end_date'";
+        }
+
+        $ec_start_date = $this->_get_clean_value($options, "estimated_close_start_date");
+        if ($ec_start_date) {
+            $where .= " AND DATE(ec.value)>='$ec_start_date'";
+        }
+        $ec_end_date = $this->_get_clean_value($options, "estimated_close_end_date");
+        if ($ec_end_date) {
+            $where .= " AND DATE(ec.value)<='$ec_end_date'";
+        }
+
+        $closed_start_date = $this->_get_clean_value($options, "closed_start_date");
+        if ($closed_start_date) {
+            $where .= " AND DATE(cd.value)>='$closed_start_date'";
+        }
+        $closed_end_date = $this->_get_clean_value($options, "closed_end_date");
+        if ($closed_end_date) {
+            $where .= " AND DATE(cd.value)<='$closed_end_date'";
+        }
+
+        $client_groups = $this->_get_clean_value($options, "client_groups");
+        $where .= $this->prepare_allowed_client_groups_query($clients_table, $client_groups);
+
+        $sql = "SELECT $clients_table.lead_status_id, $lead_status_table.title AS status_title,
+                       $lead_status_table.color AS status_color,
+                       SUM(IFNULL(volume.value,0)) AS volume,
+                       SUM(IFNULL(margin.value,0) * IFNULL(volume.value,0)) AS potential_margin
+                FROM $clients_table
+                LEFT JOIN $cf_table AS volume ON volume.custom_field_id=273 AND volume.related_to_type='clients' AND volume.related_to_id=$clients_table.id AND volume.deleted=0
+                LEFT JOIN $cf_table AS margin ON margin.custom_field_id=241 AND margin.related_to_type='clients' AND margin.related_to_id=$clients_table.id AND margin.deleted=0
+                LEFT JOIN $cf_table AS ec ON ec.custom_field_id=167 AND ec.related_to_type='clients' AND ec.related_to_id=$clients_table.id AND ec.deleted=0
+                LEFT JOIN $cf_table AS cd ON cd.custom_field_id=272 AND cd.related_to_type='clients' AND cd.related_to_id=$clients_table.id AND cd.deleted=0
+                LEFT JOIN $lead_status_table ON $lead_status_table.id=$clients_table.lead_status_id
+                WHERE $clients_table.deleted=0 AND $clients_table.is_lead=0 $where
+                GROUP BY $clients_table.lead_status_id
+                ORDER BY $lead_status_table.sort ASC";
+
+        return $this->db->query($sql)->getResult();
+    }
 }

--- a/app/Views/clients/reports/client_summary.php
+++ b/app/Views/clients/reports/client_summary.php
@@ -2,6 +2,10 @@
 
 <div id="page-content" class="page-wrapper clearfix">
     <div id="client-dashboard-summary-container" class="mb20"></div>
+    <div class="bg-white mb20">
+        <div id="clients-report-chart-filters"></div>
+    </div>
+    <div id="clients-report-charts" class="mb20"></div>
     <div class="card clearfix">
         <div class="table-responsive">
             <table id="clients-report-table" class="display" width="100%"></table>
@@ -19,6 +23,16 @@
             {id: "person", text: "<?php echo app_lang('person'); ?>"},
             {id: "organization", text: "<?php echo app_lang('organization'); ?>"}
         ];
+
+        var statusOptions = <?php
+            $status_dropdown = array();
+            if (isset($statuses)) {
+                foreach ($statuses as $s) {
+                    $status_dropdown[] = array("text" => $s->title, "value" => $s->id);
+                }
+            }
+            echo json_encode($status_dropdown);
+        ?>;
 
         var columns = [
             {title: "<?php echo app_lang('id'); ?>", class: "text-center w50 desktop", order_by: "id"},
@@ -66,6 +80,26 @@
         };
 
         var quick_filters_dropdown = <?php echo view("clients/quick_filters_dropdown"); ?>;
+
+        $("#clients-report-chart-filters").appFilters({
+            source: '<?php echo_uri("clients/clients_report_charts_data") ?>',
+            targetSelector: '#clients-report-charts',
+            filterDropdown: [
+                {name: "owner_id", class: "w200", options: <?php echo $team_members_dropdown; ?>},
+                {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
+                {name: "account_type", class: "w200", options: type_dropdown},
+                {name: "source_id", class: "w200", options: <?php echo view("leads/lead_sources", array("lead_sources" => $lead_sources)); ?>}
+            ],
+            multiSelect: [
+                {name: "status_id", text: "<?php echo app_lang('status'); ?>", options: statusOptions, class: "w200"}
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true},
+                {startDate: {name: "estimated_close_start_date", value: ""}, endDate: {name: "estimated_close_end_date", value: ""}, label: "Estimated Close", showClearButton: true},
+                {startDate: {name: "closed_start_date", value: ""}, endDate: {name: "closed_end_date", value: ""}, label: "Closed Date", showClearButton: true}
+            ]
+        });
+
         $("#clients-report-table").appTable({
             source: '<?php echo_uri("clients/clients_report_list_data") ?>',
             filterDropdown: [

--- a/app/Views/clients/reports/margin_volume_chart.php
+++ b/app/Views/clients/reports/margin_volume_chart.php
@@ -1,0 +1,76 @@
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <canvas id="potential-margin-chart" style="width:100%; height:350px;"></canvas>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <canvas id="volume-chart" style="width:100%; height:350px;"></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        var marginCtx = document.getElementById("potential-margin-chart");
+        new Chart(marginCtx, {
+            type: 'bar',
+            data: {
+                labels: <?php echo $labels; ?>,
+                datasets: [{
+                    label: '<?php echo app_lang('potential_margin'); ?>',
+                    data: <?php echo $margin_data; ?>,
+                    backgroundColor: '#28a745'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: {display: false},
+                scales: {
+                    xAxes: [{
+                        gridLines: {color: 'rgba(127,127,127,0.1)'},
+                        ticks: {fontColor: '#898fa9'}
+                    }],
+                    yAxes: [{
+                        gridLines: {color: 'rgba(127,127,127,0.1)'},
+                        ticks: {fontColor: '#898fa9'}
+                    }]
+                }
+            }
+        });
+
+        var volumeCtx = document.getElementById("volume-chart");
+        new Chart(volumeCtx, {
+            type: 'bar',
+            data: {
+                labels: <?php echo $labels; ?>,
+                datasets: [{
+                    label: '<?php echo app_lang('volume'); ?>',
+                    data: <?php echo $volume_data; ?>,
+                    backgroundColor: '#3B81F6'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                legend: {display: false},
+                scales: {
+                    xAxes: [{
+                        gridLines: {color: 'rgba(127,127,127,0.1)'},
+                        ticks: {fontColor: '#898fa9'}
+                    }],
+                    yAxes: [{
+                        gridLines: {color: 'rgba(127,127,127,0.1)'},
+                        ticks: {fontColor: '#898fa9'}
+                    }]
+                }
+            }
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add potential margin/volume aggregation in `Clients_model`
- expose chart data via new `clients_report_charts_data` controller method
- create `margin_volume_chart` view with two Chart.js graphs
- embed charts and filters in `client_summary` reports view

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Clients.php`
- `php -l app/Views/clients/reports/margin_volume_chart.php`
- `php -l app/Views/clients/reports/client_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_688a08a336948332a7068ad2f0af585e