### PR TITLE
Fix lead owner display

### DIFF
--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -325,7 +325,7 @@
 
         $('#owner_id').select2({
             data: <?php echo json_encode($owners_dropdown); ?>
-        });
+        }).val('<?php echo $model_info->owner_id ? $model_info->owner_id : $login_user->id; ?>').trigger('change');
 
         $("#lead_labels").select2({
             multiple: true,


### PR DESCRIPTION
## Summary
- ensure the owner field defaults to the current user name on the lead form

## Testing
- `php -l app/Views/leads/lead_form_fields.php`


------
https://chatgpt.com/codex/tasks/task_e_688a35d3f06483328c697ff0a053704e