### PR TITLE
Add Fill the Funnel Leaderboard report

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2132,6 +2132,44 @@ private function _save_a_row_of_excel_data($row_data) {
         return $this->template->view("clients/reports/margin_volume_chart", $view_data);
     }
 
+    function fill_the_funnel_leaderboard() {
+        $this->access_only_allowed_members();
+
+        return $this->template->view("clients/reports/fill_the_funnel_leaderboard");
+    }
+
+    function fill_the_funnel_leaderboard_data() {
+        $this->access_only_allowed_members();
+
+        $options = array(
+            "start_date" => "2025-07-21",
+            "end_date" => "2025-09-30"
+        );
+
+        $list_data = $this->Clients_model->get_fill_the_funnel_leaderboard($options)->getResult();
+
+        $result = array();
+        foreach ($list_data as $data) {
+            $result[] = $this->_make_fill_the_funnel_leaderboard_row($data);
+        }
+
+        echo json_encode(array("data" => $result));
+    }
+
+    private function _make_fill_the_funnel_leaderboard_row($data) {
+        $points = ($data->new_opportunities * 10) + ($data->closed_deals * 50);
+
+        $member = get_team_member_profile_link($data->staff_id, $data->sales_rep_name);
+
+        return array(
+            $member,
+            $data->roc,
+            $data->new_opportunities,
+            $data->closed_deals,
+            $points
+        );
+    }
+
     function load_client_dashboard_summary() {
         $this->access_only_allowed_members();
 

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -96,6 +96,7 @@ if (!function_exists('get_reports_topbar')) {
         if (get_setting("module_lead") == "1" && ($ci->login_user->is_admin || $access_lead == "all")) {
             $reports_menu[] = array("name" => "leads", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
             $reports_menu[] = array("name" => "clients", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
+            $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2778,5 +2778,12 @@ $lang["phone_minlength_error"] = "Phone number must be at least 10 digits";
 $lang["enter_valid_email"] = "Please enter a valid email address";
 $lang["company_name_custom"] = "Customer Name";
 
+$lang["fill_the_funnel_leaderboard"] = "Fill the Funnel - Leaderboard";
+$lang["sales_rep_name"] = "Sales Rep Name";
+$lang["roc"] = "ROC";
+$lang["new_opportunities"] = "New Opportunities";
+$lang["closed_deals"] = "Closed Deals";
+$lang["total_points"] = "Total Points";
+
 
 return $lang;

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1059,4 +1059,34 @@ function get_details($options = array()) {
 
         return $this->db->query($sql)->getResult();
     }
+
+    function get_fill_the_funnel_leaderboard($options = array()) {
+        $clients_table = $this->db->prefixTable('clients');
+        $users_table = $this->db->prefixTable('users');
+        $cf_table = $this->db->prefixTable('custom_field_values');
+
+        $start_date = $this->_get_clean_value($options, "start_date");
+        $end_date = $this->_get_clean_value($options, "end_date");
+
+        $where = " AND $clients_table.is_lead=1 AND $clients_table.deleted=0";
+        if ($start_date && $end_date) {
+            $where .= " AND DATE($clients_table.created_date) BETWEEN '$start_date' AND '$end_date'";
+        }
+
+        //only include clients which have the custom field value 273
+        $where .= " AND cf_273.value IS NOT NULL";
+
+        $sql = "SELECT $users_table.id AS staff_id,
+                        CONCAT($users_table.first_name, ' ', $users_table.last_name) AS sales_rep_name,
+                        $users_table.address AS roc,
+                        COUNT($clients_table.id) AS new_opportunities,
+                        SUM(IF($clients_table.lead_status_id=6,1,0)) AS closed_deals
+                FROM $clients_table
+                LEFT JOIN $cf_table AS cf_273 ON cf_273.custom_field_id=273 AND cf_273.related_to_type='clients' AND cf_273.related_to_id=$clients_table.id AND cf_273.deleted=0
+                LEFT JOIN $users_table ON $users_table.id=$clients_table.owner_id
+                WHERE $users_table.deleted=0 AND $users_table.status='active' AND $users_table.user_type='staff' $where
+                GROUP BY $users_table.id";
+
+        return $this->db->query($sql);
+    }
 }

--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -1,0 +1,25 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="table-responsive">
+            <table id="fill-the-funnel-leaderboard" class="display" width="100%">
+            </table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#fill-the-funnel-leaderboard").appTable({
+            source: '<?php echo_uri("clients/fill_the_funnel_leaderboard_data") ?>',
+            columns: [
+                {title: '<?php echo app_lang("sales_rep_name"); ?>', class: "all"},
+                {title: '<?php echo app_lang("roc"); ?>'},
+                {title: '<?php echo app_lang("new_opportunities"); ?>', class: "text-center"},
+                {title: '<?php echo app_lang("closed_deals"); ?>', class: "text-center"},
+                {title: '<?php echo app_lang("total_points"); ?>', class: "text-center"}
+            ]
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add leaderboard report backend and DB query
- create leaderboard view
- hook up new item in reports menu
- add translations for leaderboard UI

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Clients.php`
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`
- `php -l app/Helpers/reports_helper.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_688a48ae8eac8332a855c0fbd7edea0c