### PR TITLE
Fix jQuery load on leaderboard view

### DIFF
--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -1,5 +1,8 @@
 <?php echo get_reports_topbar(); ?>
 
+<!-- Make sure jQuery is available before executing page scripts -->
+<script src="<?php echo base_url('assets/js/jquery-3.5.1.min.js'); ?>"></script>
+
 <div id="page-content" class="page-wrapper clearfix">
     <div class="card clearfix">
         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- add jQuery import for leaderboard view so `$` is defined

## Testing
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688aaecae57883328b1c87ce93a509c5