### PR TITLE
Fix Fill the Funnel leaderboard loading

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2135,7 +2135,7 @@ private function _save_a_row_of_excel_data($row_data) {
     function fill_the_funnel_leaderboard() {
         $this->access_only_allowed_members();
 
-        return $this->template->view("clients/reports/fill_the_funnel_leaderboard");
+        return $this->template->rander("clients/reports/fill_the_funnel_leaderboard");
     }
 
     function fill_the_funnel_leaderboard_data() {

--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -1,8 +1,5 @@
 <?php echo get_reports_topbar(); ?>
 
-<!-- Make sure jQuery is available before executing page scripts -->
-<script src="<?php echo base_url('assets/js/jquery-3.5.1.min.js'); ?>"></script>
-
 <div id="page-content" class="page-wrapper clearfix">
     <div class="card clearfix">
         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- render the Fill the Funnel leaderboard through the main layout
- remove redundant jQuery include from the leaderboard view

## Testing
- `php -v`
- `php -l app/Controllers/Clients.php`
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688ab071fa708332a065e143732e2046