### PR TITLE
Add lead status to client modal

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -122,7 +122,8 @@ class Clients extends Security_Controller {
             "website" => $this->request->getPost('website'),
             "vat_number" => $this->request->getPost('vat_number'),
             "gst_number" => $this->request->getPost('gst_number'),
-            "lead_source_id" => $this->request->getPost('lead_source_id')
+            "lead_source_id" => $this->request->getPost('lead_source_id'),
+            "lead_status_id" => $this->request->getPost('lead_status_id') ? $this->request->getPost('lead_status_id') : 1
         );
 
     if ($this->login_user->user_type === "staff") {

--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -98,6 +98,22 @@
 
 <div class="form-group">
     <div class="row">
+        <label for="client_lead_status_id" class="<?php echo $label_column; ?>"><?php echo app_lang('status'); ?></label>
+        <div class="<?php echo $field_column; ?>">
+            <?php
+            $lead_status_dropdown = array();
+            foreach ($statuses as $status) {
+                $lead_status_dropdown[$status->id] = $status->title;
+            }
+            $selected_status = $model_info->lead_status_id ? $model_info->lead_status_id : 1;
+            echo form_dropdown("lead_status_id", $lead_status_dropdown, array($selected_status), "class='select2' id='client_lead_status_id'");
+            ?>
+        </div>
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="row">
         <label for="client_lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
         <div class="<?php echo $field_column; ?>">
             <?php echo view('partials/lead_source_select', ['sources_dropdown' => $sources_dropdown, 'selected' => $model_info->lead_source_id, 'id' => 'client_lead_source_id']); ?>
@@ -366,6 +382,8 @@
                 data: <?php echo $team_members_dropdown; ?>
             });
         <?php } ?>
+
+        $('#client_lead_status_id').select2();
 
         <?php if ($login_user->user_type === "staff") { ?>
             $("#client_labels").select2({


### PR DESCRIPTION
## Summary
- show lead status dropdown on add/edit client form
- initialize lead status select2
- persist `lead_status_id` when saving clients, defaulting to status id 1

## Testing
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Controllers/Clients.php`


------
https://chatgpt.com/codex/tasks/task_e_688bbe0b78e0833291233f2715ac8210