### PR TITLE
Update add client modal defaults

### DIFF
--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -322,7 +322,7 @@
     </div>
 
 <?php } ?>
-<?php if ($login_user->user_type === "staff") { ?>
+<?php if ($login_user->user_type === "staff" && empty($hide_client_labels)) { ?>
     <div class="form-group">
         <div class="row">
             <label for="client_labels" class="<?php echo $label_column; ?>"><?php echo app_lang('labels'); ?></label>
@@ -385,7 +385,7 @@
 
         $('#client_lead_status_id').select2();
 
-        <?php if ($login_user->user_type === "staff") { ?>
+        <?php if ($login_user->user_type === "staff" && empty($hide_client_labels)) { ?>
             $("#client_labels").select2({
                 multiple: true,
                 data: <?php echo json_encode($label_suggestions); ?>

--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -2,7 +2,13 @@
 <div class="modal-body clearfix">
     <div class="container-fluid">
         <input type="hidden" name="ticket_id" value="<?php echo $ticket_id; ?>" />
-        <?php echo view("clients/client_form_fields"); ?>
+        <?php
+            // Default the country to Canada when adding a new client
+            if (!$model_info->country) {
+                $model_info->country = "Canada";
+            }
+            echo view("clients/client_form_fields", ["hide_client_labels" => true]);
+        ?>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- default to Canada when adding a new client
- hide labels field in the add client modal view

## Testing
- `php -l app/Views/clients/modal_form.php`
- `php -l app/Views/clients/client_form_fields.php`

------
https://chatgpt.com/codex/tasks/task_e_688bc0a891988332ae0d23e74bbbd135