### PR TITLE
Fix Fill the Funnel leaderboard filtering

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2174,8 +2174,8 @@ private function _save_a_row_of_excel_data($row_data) {
         $this->access_only_allowed_members();
 
         $options = array(
-            "start_date" => "2025-07-21",
-            "end_date" => "2025-09-30"
+            "start_date" => $this->request->getPost("start_date"),
+            "end_date" => $this->request->getPost("end_date")
         );
 
         $list_data = $this->Clients_model->get_fill_the_funnel_leaderboard($options)->getResult();

--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -13,6 +13,7 @@
     $(document).ready(function () {
         $("#fill-the-funnel-leaderboard").appTable({
             source: '<?php echo_uri("clients/fill_the_funnel_leaderboard_data") ?>',
+            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, showClearButton: true}],
             columns: [
                 {title: '<?php echo app_lang("sales_rep_name"); ?>', class: "all"},
                 {title: '<?php echo app_lang("roc"); ?>'},


### PR DESCRIPTION
## Summary
- ensure Fill the Funnel report uses user-selected date range
- add date range picker on the Fill the Funnel page

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688bc9195a888332b4d43953d68f9949