### PR TITLE
Add region leaderboard and default dates

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2202,6 +2202,35 @@ private function _save_a_row_of_excel_data($row_data) {
         );
     }
 
+    function fill_the_funnel_region_leaderboard_data() {
+        $this->access_only_allowed_members();
+
+        $options = array(
+            "start_date" => $this->request->getPost("start_date"),
+            "end_date" => $this->request->getPost("end_date")
+        );
+
+        $list_data = $this->Clients_model->get_fill_the_funnel_region_leaderboard($options)->getResult();
+
+        $result = array();
+        foreach ($list_data as $data) {
+            $result[] = $this->_make_fill_the_funnel_region_leaderboard_row($data);
+        }
+
+        echo json_encode(array("data" => $result));
+    }
+
+    private function _make_fill_the_funnel_region_leaderboard_row($data) {
+        $points = ($data->new_opportunities * 10) + ($data->closed_deals * 50);
+
+        return array(
+            $data->roc,
+            $data->new_opportunities,
+            $data->closed_deals,
+            $points
+        );
+    }
+
     function load_client_dashboard_summary() {
         $this->access_only_allowed_members();
 

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2786,4 +2786,5 @@ $lang["roc"] = "ROC";
 $lang["new_opportunities"] = "New Opportunities";
 $lang["closed_deals"] = "Closed Deals";
 $lang["total_points"] = "Total Points";
+$lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderboard";
 return $lang;

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1089,4 +1089,40 @@ function get_details($options = array()) {
 
         return $this->db->query($sql);
     }
+
+    function get_fill_the_funnel_region_leaderboard($options = array()) {
+        $clients_table = $this->db->prefixTable('clients');
+        $users_table = $this->db->prefixTable('users');
+        $cf_table = $this->db->prefixTable('custom_field_values');
+
+        $start_date = $this->_get_clean_value($options, "start_date");
+        $end_date = $this->_get_clean_value($options, "end_date");
+
+        $where = " AND $clients_table.is_lead=0 AND $clients_table.deleted=0";
+        if ($start_date && $end_date) {
+            $where .= " AND DATE($clients_table.created_date) BETWEEN '$start_date' AND '$end_date'";
+        }
+
+        //only include clients which have the custom field value 273
+        $where .= " AND cf_273.value IS NOT NULL";
+
+        $sql = "SELECT
+                    CASE
+                        WHEN LOWER($users_table.address) LIKE '%atlantic%' THEN 'Atlantic'
+                        WHEN LOWER($users_table.address) LIKE '%quebec%' THEN 'Quebec'
+                        WHEN LOWER($users_table.address) LIKE '%ontario%' THEN 'Ontario'
+                        WHEN LOWER($users_table.address) LIKE '%pacific%' THEN 'Pacific'
+                        WHEN LOWER($users_table.address) LIKE '%prairies%' THEN 'Prairies'
+                        ELSE 'Other'
+                    END AS roc,
+                    COUNT($clients_table.id) AS new_opportunities,
+                    SUM(IF($clients_table.lead_status_id=6,1,0)) AS closed_deals
+                FROM $clients_table
+                LEFT JOIN $cf_table AS cf_273 ON cf_273.custom_field_id=273 AND cf_273.related_to_type='clients' AND cf_273.related_to_id=$clients_table.id AND cf_273.deleted=0
+                LEFT JOIN $users_table ON $users_table.id=$clients_table.owner_id
+                WHERE $users_table.deleted=0 AND $users_table.status='active' AND $users_table.user_type='staff' $where
+                GROUP BY roc";
+
+        return $this->db->query($sql);
+    }
 }

--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -3,8 +3,12 @@
 <div id="page-content" class="page-wrapper clearfix">
     <div class="card clearfix">
         <div class="table-responsive">
-            <table id="fill-the-funnel-leaderboard" class="display" width="100%">
-            </table>
+            <table id="fill-the-funnel-leaderboard" class="display" width="100%"></table>
+        </div>
+    </div>
+    <div class="card clearfix mt20">
+        <div class="table-responsive">
+            <table id="fill-the-funnel-region-leaderboard" class="display" width="100%"></table>
         </div>
     </div>
 </div>
@@ -13,14 +17,29 @@
     $(document).ready(function () {
         $("#fill-the-funnel-leaderboard").appTable({
             source: '<?php echo_uri("clients/fill_the_funnel_leaderboard_data") ?>',
-            rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, showClearButton: true}],
+            rangeDatepicker: [{startDate: {name: "start_date", value: "2025-07-21"}, endDate: {name: "end_date", value: "2025-09-30"}, showClearButton: true}],
             columns: [
                 {title: '<?php echo app_lang("sales_rep_name"); ?>', class: "all"},
                 {title: '<?php echo app_lang("roc"); ?>'},
                 {title: '<?php echo app_lang("new_opportunities"); ?>', class: "text-center"},
                 {title: '<?php echo app_lang("closed_deals"); ?>', class: "text-center"},
                 {title: '<?php echo app_lang("total_points"); ?>', class: "text-center"}
-            ]
+            ],
+            printColumns: [0, 1, 2, 3, 4],
+            xlsColumns: [0, 1, 2, 3, 4]
+        });
+
+        $("#fill-the-funnel-region-leaderboard").appTable({
+            source: '<?php echo_uri("clients/fill_the_funnel_region_leaderboard_data") ?>',
+            rangeDatepicker: [{startDate: {name: "start_date", value: "2025-07-21"}, endDate: {name: "end_date", value: "2025-09-30"}, showClearButton: true}],
+            columns: [
+                {title: '<?php echo app_lang("region"); ?>'},
+                {title: '<?php echo app_lang("new_opportunities"); ?>', class: "text-center"},
+                {title: '<?php echo app_lang("closed_deals"); ?>', class: "text-center"},
+                {title: '<?php echo app_lang("total_points"); ?>', class: "text-center"}
+            ],
+            printColumns: [0, 1, 2, 3],
+            xlsColumns: [0, 1, 2, 3]
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- default leaderboard date filters to 2025-07-21 — 2025-09-30
- add Region Leaderboard table below Fill the Funnel report
- implement new endpoints and model query for region leaderboard
- add language string

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688bd587b13c8332b5f15f1b5a741c19