### PR TITLE
Fix report menu labels

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -94,8 +94,8 @@ if (!function_exists('get_reports_topbar')) {
         }
 
         if (get_setting("module_lead") == "1" && ($ci->login_user->is_admin || $access_lead == "all")) {
-            $reports_menu[] = array("name" => "leads", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
-            $reports_menu[] = array("name" => "clients", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
+            $reports_menu[] = array("name" => "opportunities_graphs", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
+            $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
             $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
         }
 

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2787,4 +2787,7 @@ $lang["new_opportunities"] = "New Opportunities";
 $lang["closed_deals"] = "Closed Deals";
 $lang["total_points"] = "Total Points";
 $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderboard";
+
+$lang["opportunities_graphs"] = "Opportunities Graphs";
+$lang["opportunity_data_reports"] = "Opportunity Data Reports";
 return $lang;


### PR DESCRIPTION
## Summary
- correct labels for leads and clients report menu items
- translate new labels in custom language file

## Testing
- `php -l app/Helpers/reports_helper.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_688bdaa57d5c8332b4de2f3351acb9c6