### PR TITLE
Restore navigation in clients Kanban view

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2044,6 +2044,7 @@ private function _save_a_row_of_excel_data($row_data) {
         $view_data['lead_sources'] = $this->Lead_source_model->get_details()->getResult();
         $view_data['labels_dropdown'] = json_encode($this->make_labels_dropdown("client", "", true));
         $view_data["custom_field_filters"] = $this->Custom_fields_model->get_custom_field_filters("clients", $this->login_user->is_admin, $this->login_user->user_type);
+        $view_data['can_edit_clients'] = $this->can_edit_clients();
 
         return $this->template->rander("clients/kanban/all_clients", $view_data);
     }

--- a/app/Views/clients/kanban/all_clients.php
+++ b/app/Views/clients/kanban/all_clients.php
@@ -1,17 +1,39 @@
-<div class="card border-top-0 rounded-top-0 mb0 mt10 no-box-shadow">
-    <div class="card-header title-tab clearfix">
-        <h4 class="float-start"><?php echo app_lang('clients'); ?></h4>
-   
-    </div>
-    <div class="bg-white">
-        <div id="kanban-filters"></div>
+<div id="page-content" class="page-wrapper pb0 clearfix grid-button clients-kanban-view">
+
+    <ul class="nav nav-tabs bg-white title" role="tablist">
+        <li class="title-tab clients-kanban">
+            <h4 class="pl15 pt10 pr15"><?php echo app_lang('clients'); ?></h4>
+        </li>
+
+        <li><a role="presentation" href="<?php echo get_uri('clients'); ?>"><?php echo app_lang('overview'); ?></a></li>
+        <li><a role="presentation" href="<?php echo get_uri('clients/clients_list'); ?>"><?php echo app_lang('clients'); ?></a></li>
+        <li class="active"><a role="presentation" href="<?php echo get_uri('clients/all_clients_kanban'); ?>"><?php echo app_lang('kanban'); ?></a></li>
+        <li><a role="presentation" href="<?php echo get_uri('clients/contacts'); ?>"><?php echo app_lang('contacts'); ?></a></li>
+
+        <div class="tab-title clearfix no-border">
+            <div class="title-button-group">
+                <?php
+                if (isset($can_edit_clients) && $can_edit_clients) {
+                    echo modal_anchor(get_uri('labels/modal_form'), "<i data-feather='tag' class='icon-16'></i> " . app_lang('manage_labels'), array("class" => "btn btn-default", "title" => app_lang('manage_labels'), "data-post-type" => "client"));
+                    echo modal_anchor(get_uri('clients/import_modal_form'), "<i data-feather='upload' class='icon-16'></i> " . app_lang('import_clients'), array("class" => "btn btn-default", "title" => app_lang('import_clients'), "id" => 'import-btn'));
+                    echo modal_anchor(get_uri('clients/modal_form'), "<i data-feather='plus-circle' class='icon-16'></i> " . app_lang('add_client'), array("class" => "btn btn-default", "title" => app_lang('add_client')));
+                }
+                ?>
+            </div>
+        </div>
+    </ul>
+
+    <div class="card border-top-0 rounded-top-0 mb0">
+        <div class="bg-white" id="js-kanban-filter-container">
+            <div id="kanban-filters"></div>
+        </div>
+
+        <div id="load-kanban"></div>
     </div>
 </div>
 
-<div id="load-kanban"></div>
-
 <script>
-    $(document).ready(function() {
+    $(document).ready(function () {
         window.scrollToKanbanContent = true;
     });
 </script>


### PR DESCRIPTION
## Summary
- expose `can_edit_clients` when loading the clients kanban page
- add navigation tabs and action buttons to the clients kanban view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be8f2631c83329b577e545bbb3283