### PR TITLE
Adjust fill the funnel report scoring criteria

### DIFF
--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1133,24 +1133,21 @@ function get_details($options = array()) {
         $users_table = $this->db->prefixTable('users');
         $cf_table = $this->db->prefixTable('custom_field_values');
 
-        $start_date = $this->_get_clean_value($options, "start_date");
-        $end_date = $this->_get_clean_value($options, "end_date");
-
         $where = " AND $clients_table.is_lead=0 AND $clients_table.deleted=0";
-        if ($start_date && $end_date) {
-            $where .= " AND DATE($clients_table.created_date) BETWEEN '$start_date' AND '$end_date'";
-        }
 
         //only include clients which have the custom field value 273
         $where .= " AND cf_273.value IS NOT NULL";
 
+        $june_23 = date('Y') . "-06-23";
+
         $sql = "SELECT $users_table.id AS staff_id,
                         CONCAT($users_table.first_name, ' ', $users_table.last_name) AS sales_rep_name,
                         $users_table.address AS roc,
-                        COUNT($clients_table.id) AS new_opportunities,
-                        SUM(IF($clients_table.lead_status_id=6,1,0)) AS closed_deals
+                        SUM(IF(DATE($clients_table.created_date) >= '$june_23',1,0)) AS new_opportunities,
+                        SUM(IF(cf_272.value IS NOT NULL,1,0)) AS closed_deals
                 FROM $clients_table
                 LEFT JOIN $cf_table AS cf_273 ON cf_273.custom_field_id=273 AND cf_273.related_to_type='clients' AND cf_273.related_to_id=$clients_table.id AND cf_273.deleted=0
+                LEFT JOIN $cf_table AS cf_272 ON cf_272.custom_field_id=272 AND cf_272.related_to_type='clients' AND cf_272.related_to_id=$clients_table.id AND cf_272.deleted=0
                 LEFT JOIN $users_table ON $users_table.id=$clients_table.owner_id
                 WHERE $users_table.deleted=0 AND $users_table.status='active' AND $users_table.user_type='staff' $where
                 GROUP BY $users_table.id";
@@ -1163,16 +1160,12 @@ function get_details($options = array()) {
         $users_table = $this->db->prefixTable('users');
         $cf_table = $this->db->prefixTable('custom_field_values');
 
-        $start_date = $this->_get_clean_value($options, "start_date");
-        $end_date = $this->_get_clean_value($options, "end_date");
-
         $where = " AND $clients_table.is_lead=0 AND $clients_table.deleted=0";
-        if ($start_date && $end_date) {
-            $where .= " AND DATE($clients_table.created_date) BETWEEN '$start_date' AND '$end_date'";
-        }
 
         //only include clients which have the custom field value 273
         $where .= " AND cf_273.value IS NOT NULL";
+
+        $june_23 = date('Y') . "-06-23";
 
         $sql = "SELECT
                     CASE
@@ -1183,10 +1176,11 @@ function get_details($options = array()) {
                         WHEN LOWER($users_table.address) LIKE '%prairies%' THEN 'Prairies'
                         ELSE 'Other'
                     END AS roc,
-                    COUNT($clients_table.id) AS new_opportunities,
-                    SUM(IF($clients_table.lead_status_id=6,1,0)) AS closed_deals
+                    SUM(IF(DATE($clients_table.created_date) >= '$june_23',1,0)) AS new_opportunities,
+                    SUM(IF(cf_272.value IS NOT NULL,1,0)) AS closed_deals
                 FROM $clients_table
                 LEFT JOIN $cf_table AS cf_273 ON cf_273.custom_field_id=273 AND cf_273.related_to_type='clients' AND cf_273.related_to_id=$clients_table.id AND cf_273.deleted=0
+                LEFT JOIN $cf_table AS cf_272 ON cf_272.custom_field_id=272 AND cf_272.related_to_type='clients' AND cf_272.related_to_id=$clients_table.id AND cf_272.deleted=0
                 LEFT JOIN $users_table ON $users_table.id=$clients_table.owner_id
                 WHERE $users_table.deleted=0 AND $users_table.status='active' AND $users_table.user_type='staff' $where
                 GROUP BY roc";


### PR DESCRIPTION
## Summary
- Update fill-the-funnel leaderboards to award 10 points for clients created on/after June 23 and 50 points for clients with a closed date (custom field 272).

## Testing
- `php -l app/Models/Clients_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68937392aa748332bdbd6784e57368b6