### PR TITLE
Add full-form link and field visibility for estimate request forms

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -422,6 +422,7 @@ private function _make_estimate_request_row($data) {
         $public = "";
         if ($data->public) {
             $public = anchor("request_estimate/form/" . $data->id, app_lang("yes") . "<i data-feather='external-link' class='icon-16 ml10'></i>", array("target" => "_blank", "class" => ""));
+            $public .= " | " . anchor("request_estimate/form/" . $data->id . "/0/1", app_lang("full_form") . "<i data-feather='external-link' class='icon-16 ml10'></i>", array("target" => "_blank", "class" => ""));
         } else {
             $public = app_lang("no");
         }
@@ -581,6 +582,7 @@ private function _make_estimate_request_row($data) {
             "placeholder" => $this->request->getPost('placeholder'),
             "placeholder_language_key" => $this->request->getPost('placeholder_language_key'),
             "required" => $this->request->getPost('required') ? 1 : 0,
+            "show_in_embedded_form" => $this->request->getPost('show_in_embedded_form') ? 1 : 0,
             "related_to" => $related_to,
             "options" => $this->request->getPost('options') ? $this->request->getPost('options') : ""
         );

--- a/app/Controllers/Request_estimate.php
+++ b/app/Controllers/Request_estimate.php
@@ -22,7 +22,7 @@ class Request_estimate extends App_Controller {
         return $this->template->rander("request_estimate/index", $view_data);
     }
 
-    function form($id = 0, $embedded = 0) {
+    function form($id = 0, $embedded = 0, $all_fields = 0) {
         if (!get_setting("module_estimate_request")) {
             show_404();
         }
@@ -42,6 +42,7 @@ class Request_estimate extends App_Controller {
         $view_data['left_menu'] = false;
 
         $view_data['embedded'] = clean_data($embedded);
+        $view_data['all_fields'] = clean_data($all_fields);
 
         $model_info = $this->Estimate_forms_model->get_one_where(array("id" => $id, "public" => "1", "status" => "active", "deleted" => 0));
 
@@ -230,10 +231,13 @@ function save_estimate_request() {
 }
 
     //prepare data for datatable for estimate form's field list
-    function estimate_form_filed_list_data($id = 0) {
+    function estimate_form_filed_list_data($id = 0, $all_fields = 0) {
         validate_numeric_value($id);
 
         $options = array("related_to" => "estimate_form-" . $id);
+        if (!$all_fields) {
+            $options["show_in_embedded_form"] = true;
+        }
         $list_data = $this->Custom_fields_model->get_details($options)->getResult();
         $result = array();
         foreach ($list_data as $data) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2791,4 +2791,6 @@ $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderbo
 $lang["opportunities_graphs"] = "Opportunities Graphs";
 $lang["opportunity_data_reports"] = "Opportunity Data Reports";
 $lang["opportunity_status"] = "Status";
+$lang['show_in_public_form'] = 'Show in public form';
+$lang['full_form'] = 'Full form';
 return $lang;

--- a/app/Views/estimate_requests/estimate_form_field_modal_form.php
+++ b/app/Views/estimate_requests/estimate_form_field_modal_form.php
@@ -6,6 +6,19 @@
 
         <?php echo view("custom_fields/form/input_fields"); ?>
 
+        <div class="form-group">
+            <div class="row">
+                <label for="show_in_embedded_form" class=" col-md-3"><?php echo app_lang('show_in_public_form'); ?></label>
+                <div class="col-md-9">
+                    <?php
+                    echo form_checkbox(
+                            "show_in_embedded_form", "1", $model_info->show_in_embedded_form, "id='show_in_embedded_form' class='form-check-input'"
+                    );
+                    ?>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-bs-dismiss="modal"><span data-feather="x" class="icon-16"></span> <?php echo app_lang('close'); ?></button>

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -358,7 +358,7 @@ table.dataTable tbody td:first-child {
     $(document).ready(function() {
         // Initialize appTable
         $("#estimate-form-table").appTable({
-            source: '<?php echo_uri("request_estimate/estimate_form_filed_list_data/" . $model_info->id) ?>',
+            source: '<?php echo_uri("request_estimate/estimate_form_filed_list_data/" . $model_info->id . "/" . $all_fields) ?>',
             order: [[1, "asc"]],
             hideTools: true,
             displayLength: 100,


### PR DESCRIPTION
## Summary
- allow marking estimate form fields for public visibility
- support full-form external URL showing all fields
- expose translations for the new options

## Testing
- `php -l app/Controllers/Estimate_requests.php`
- `php -l app/Controllers/Request_estimate.php`
- `php -l app/Views/estimate_requests/estimate_form_field_modal_form.php`
- `php -l app/Views/request_estimate/estimate_request_form.php`
- `php -l app/Language/english/custom_lang.php`
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897dfb128008332bf6c53043debca4e