### PR TITLE
Add custom fields and filter to estimate request list

### DIFF
--- a/app/Controllers/Estimate_requests.php
+++ b/app/Controllers/Estimate_requests.php
@@ -46,6 +46,14 @@ class Estimate_requests extends Security_Controller {
 
         $view_data['forms_dropdown'] = json_encode($forms_dropdown);
 
+        //prepare Threaten to leave filter list (custom field 287)
+        $threaten_dropdown = array(
+            array("id" => "", "text" => "- Threaten leave -"),
+            array("id" => "Yes", "text" => "Yes"),
+            array("id" => "No", "text" => "No")
+        );
+        $view_data['threaten_dropdown'] = json_encode($threaten_dropdown);
+
         return $this->template->rander('estimate_requests/index', $view_data);
     }
 
@@ -108,7 +116,8 @@ class Estimate_requests extends Security_Controller {
             "status" => $this->request->getPost("status"),
             "estimate_form_id" => $this->request->getPost("form_id"),
             "start_date" => $this->request->getPost("start_date"),
-            "end_date" => $this->request->getPost("end_date")
+            "end_date" => $this->request->getPost("end_date"),
+            "custom_field_filter_287" => $this->request->getPost("custom_field_filter_287")
         );
         $list_data = $this->Estimate_requests_model->get_details($options)->getResult();
         $result = array();
@@ -170,7 +179,7 @@ private function _make_estimate_request_row($data) {
         }
     }
 
-        // Fetch custom field values for IDs 246, 267, 268, 269, 270, 271 and 275
+        // Fetch custom field values for IDs 246, 267, 268, 269, 270, 271, 275 and 281-287
         $custom_field_246 = "";
         $custom_field_267 = "";
         $custom_field_268 = "";
@@ -178,10 +187,17 @@ private function _make_estimate_request_row($data) {
         $custom_field_270 = "";
         $custom_field_271 = "";
         $custom_field_275 = "";
+        $custom_field_281 = "";
+        $custom_field_282 = "";
+        $custom_field_283 = "";
+        $custom_field_284 = "";
+        $custom_field_285 = "";
+        $custom_field_286 = "";
+        $custom_field_287 = "";
         $custom_field_values = $this->Custom_field_values_model->get_details(array(
             "related_to_type" => "estimate_request",
             "related_to_id" => $data->id,
-            "custom_field_id" => array(246, 267, 268, 269, 270, 271, 275) // Fetch these IDs
+            "custom_field_id" => array(246, 267, 268, 269, 270, 271, 275, 281, 282, 283, 284, 285, 286, 287)
         ))->getResult();
 
     foreach ($custom_field_values as $field) {
@@ -199,6 +215,20 @@ private function _make_estimate_request_row($data) {
             $custom_field_271 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
         } elseif ($field->custom_field_id == 275) {
             $custom_field_275 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 281) {
+            $custom_field_281 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 282) {
+            $custom_field_282 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 283) {
+            $custom_field_283 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 284) {
+            $custom_field_284 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 285) {
+            $custom_field_285 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 286) {
+            $custom_field_286 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
+        } elseif ($field->custom_field_id == 287) {
+            $custom_field_287 = $this->template->view("custom_fields/output_" . $field->custom_field_type, array("value" => $field->value));
         }
     }
 
@@ -240,6 +270,13 @@ private function _make_estimate_request_row($data) {
         $custom_field_271,
         $custom_field_275,
         $assigned_to,
+        $custom_field_281,
+        $custom_field_282,
+        $custom_field_283,
+        $custom_field_284,
+        $custom_field_285,
+        $custom_field_286,
+        $custom_field_287,
         $data->created_at,
         format_to_datetime($data->created_at),
         $status,

--- a/app/Models/Estimate_requests_model.php
+++ b/app/Models/Estimate_requests_model.php
@@ -57,6 +57,12 @@ class Estimate_requests_model extends Crud_model {
             $where .= " AND DATE($estimate_requests_table.created_at) <= '$end_date'";
         }
 
+        $custom_field_filter_287 = $this->_get_clean_value($options, "custom_field_filter_287");
+        if ($custom_field_filter_287) {
+            $cf_table = $this->db->prefixTable('custom_field_values');
+            $where .= " AND $estimate_requests_table.id IN (SELECT $cf_table.related_to_id FROM $cf_table WHERE $cf_table.related_to_type='estimate_request' AND $cf_table.custom_field_id=287 AND $cf_table.deleted=0 AND $cf_table.value='$custom_field_filter_287')";
+        }
+
         $clients_only = $this->_get_clean_value($options, "clients_only");
         if ($clients_only) {
             $where .= " AND $estimate_requests_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.is_lead=0)";

--- a/app/Views/estimate_requests/index.php
+++ b/app/Views/estimate_requests/index.php
@@ -24,7 +24,8 @@
             filterDropdown: [
                 {name: "assigned_to", class: "w150", options: <?php echo $assigned_to_dropdown; ?>},
                 {name: "status", class: "w150", options: <?php echo $statuses_dropdown; ?>},
-                {name: "form_id", class: "w150", options: <?php echo $forms_dropdown; ?>}
+                {name: "form_id", class: "w150", options: <?php echo $forms_dropdown; ?>},
+                {name: "custom_field_filter_287", class: "w150", options: <?php echo $threaten_dropdown; ?>}
             ],
             rangeDatepicker: [{startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}],
             columns: [
@@ -43,13 +44,20 @@
                 {title: "Additional Info"},
                 {title: "Branch"},
                 {title: "<?php echo app_lang('assigned_to'); ?>"},
+                {title: "Tank size"},
+                {title: "Annual L"},
+                {title: "Fixed price"},
+                {title: "Last yr price"},
+                {title: "# del last yr"},
+                {title: "Buyers group"},
+                {title: "Threaten leave"},
                 {visible: false, searchable: false},
-                {title: '<?php echo app_lang("created_date") ?>', "iDataSort": 15},
+                {title: '<?php echo app_lang("created_date") ?>', "iDataSort": 22},
                 {title: "<?php echo app_lang('status'); ?>"},
                 {title: "<i data-feather='menu' class='icon-16'></i>", "class": "text-center dropdown-option w50"}
             ],
-            printColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17],
-            xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17]
+            printColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24],
+            xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24]
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- display tank size, annual litres, fixed price fields and more on estimate request list
- allow filtering requests by "Threaten leave" custom field
- include new fields in table export options

## Testing
- `php -l app/Controllers/Estimate_requests.php`
- `php -l app/Models/Estimate_requests_model.php`
- `php -l app/Views/estimate_requests/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6898d3d2ec808332a5ec9de4260f0100