### PR TITLE
feat: sort funnel leaderboard by points

### DIFF
--- a/app/Views/clients/reports/fill_the_funnel_leaderboard.php
+++ b/app/Views/clients/reports/fill_the_funnel_leaderboard.php
@@ -25,6 +25,7 @@
                 {title: '<?php echo app_lang("closed_deals"); ?>', class: "text-center"},
                 {title: '<?php echo app_lang("total_points"); ?>', class: "text-center"}
             ],
+            order: [[4, "desc"]],
             printColumns: [0, 1, 2, 3, 4],
             xlsColumns: [0, 1, 2, 3, 4]
         });
@@ -38,6 +39,7 @@
                 {title: '<?php echo app_lang("closed_deals"); ?>', class: "text-center"},
                 {title: '<?php echo app_lang("total_points"); ?>', class: "text-center"}
             ],
+            order: [[3, "desc"]],
             printColumns: [0, 1, 2, 3],
             xlsColumns: [0, 1, 2, 3]
         });


### PR DESCRIPTION
## Summary
- default sort fill-the-funnel leaderboards by total points descending

## Testing
- `php -l app/Views/clients/reports/fill_the_funnel_leaderboard.php`


------
https://chatgpt.com/codex/tasks/task_e_689a2921a89883329c52a34e9b6eec55