### PR TITLE
Include lead form data in lead created emails

### DIFF
--- a/app/Controllers/Email_templates.php
+++ b/app/Controllers/Email_templates.php
@@ -63,6 +63,27 @@ class Email_templates extends Security_Controller {
             );
         }
 
+        if (get_setting("module_lead")) {
+            $templates_array["lead"] = array(
+                "lead_created" => array(
+                    "LEAD_ID",
+                    "CONTACT_FIRST_NAME",
+                    "CONTACT_LAST_NAME",
+                    "SIGNATURE",
+                    "LEAD_URL",
+                    "LOGO_URL",
+                    "RECIPIENTS_EMAIL_ADDRESS",
+                    "FORM_DATA",
+                    "CUSTOM_FIELD_VALUES",
+                    "FILES_DATA",
+                    "NO_FORM_DATA",
+                    "NO_CUSTOM_FIELDS",
+                    "NO_FILES",
+                    "SITE_URL"
+                )
+            );
+        }
+
         if (get_setting("module_invoice")) {
             $templates_array["invoice"] = array(
                 "send_invoice" => array("INVOICE_ID", "CONTACT_FIRST_NAME", "CONTACT_LAST_NAME", "PROJECT_TITLE", "BALANCE_DUE", "DUE_DATE", "SIGNATURE", "INVOICE_URL", "LOGO_URL", "PUBLIC_PAY_INVOICE_URL", "INVOICE_FULL_ID", "RECIPIENTS_EMAIL_ADDRESS"),

--- a/app/Helpers/notifications_helper.php
+++ b/app/Helpers/notifications_helper.php
@@ -834,6 +834,30 @@ if (!function_exists('send_notification_emails')) {
             $order_data = get_order_making_data($notification->order_id);
             $attachement_url = prepare_order_pdf($order_data, "send_email");
             $email_options["attachments"] = array(array("file_path" => $attachement_url));
+        } else if ($notification->event == "lead_created") {
+            $template_name = "lead_created";
+
+            $primary_contact = $ci->Clients_model->get_primary_contact($notification->lead_id, true);
+            $parser_data["CONTACT_FIRST_NAME"] = isset($primary_contact->first_name) ? $primary_contact->first_name : "";
+            $parser_data["CONTACT_LAST_NAME"] = isset($primary_contact->last_name) ? $primary_contact->last_name : "";
+
+            $parser_data["LEAD_ID"] = $notification->lead_id;
+            $parser_data["LEAD_URL"] = $url;
+
+            if ($notification->description) {
+                $extra_data = json_decode($notification->description, true);
+
+                if (!$extra_data && json_last_error() !== JSON_ERROR_NONE) {
+                    $extra_data = json_decode(stripslashes($notification->description), true);
+                }
+
+                if (is_array($extra_data)) {
+                    $parser_data['FORM_DATA'] = get_array_value($extra_data, 'form_data');
+                    $parser_data['CUSTOM_FIELD_VALUES'] = get_array_value($extra_data, 'custom_field_values');
+                    $parser_data['FILES_DATA'] = get_array_value($extra_data, 'files_data');
+                    $parser_data['SITE_URL'] = get_uri();
+                }
+            }
         } else if ($notification->event == "project_completed") {
             $template_name = "project_completed";
 


### PR DESCRIPTION
## Summary
- capture form and custom field data when leads are saved
- add lead_created email template with form data placeholders
- include lead details in notification emails for new leads

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Controllers/Collect_leads.php`
- `php -l app/Helpers/notifications_helper.php`
- `php -l app/Controllers/Email_templates.php`


------
https://chatgpt.com/codex/tasks/task_e_689f8646f6a0833282e8be8daf0b92f4