### PR TITLE
Fix lead notification emails to include lead custom fields

### DIFF
--- a/app/Controllers/Collect_leads.php
+++ b/app/Controllers/Collect_leads.php
@@ -146,18 +146,20 @@ class Collect_leads extends App_Controller {
 
         $notification_data = array(
             "lead_id" => $lead_id,
-            "user_id" => 0,
             "form_data" => $form_data,
             "custom_field_values" => $custom_field_values,
             "files_data" => array()
         );
 
         // Log the notification with details
-        log_notification("lead_created", array(
-            "lead_id" => $lead_id,
-            "user_id" => 0,
-            "description" => json_encode($notification_data)
-        ));
+        log_notification(
+            "lead_created",
+            array(
+                "lead_id" => $lead_id,
+                "description" => json_encode($notification_data)
+            ),
+            "0"
+        );
 
 $after_submit_action_of_public_lead_form = get_setting("after_submit_action_of_public_lead_form");
 $after_submit_action_of_public_lead_form_redirect_url = get_setting("after_submit_action_of_public_lead_form_redirect_url");

--- a/app/Models/Notifications_model.php
+++ b/app/Models/Notifications_model.php
@@ -42,7 +42,20 @@ class Notifications_model extends Crud_model {
 
         $notification_settings = $this->db->query("SELECT * FROM $notification_settings_table WHERE  $notification_settings_table.event='$event' AND ($notification_settings_table.enable_email OR $notification_settings_table.enable_web OR $notification_settings_table.enable_slack)")->getRow();
         if (!$notification_settings) {
-            return false; //no notification settings found
+            if ($event === "lead_created") {
+                $notification_settings = (object) [
+                    "event" => "lead_created",
+                    "category" => "lead",
+                    "enable_email" => 1,
+                    "enable_web" => 1,
+                    "enable_slack" => 0,
+                    "notify_to_terms" => "owner,team_members,team",
+                    "notify_to_team_members" => "",
+                    "notify_to_team" => ""
+                ];
+            } else {
+                return false; //no notification settings found
+            }
         }
 
         $where = "";


### PR DESCRIPTION
## Summary
- include lead form custom fields when parsing `lead_created` notification templates
- ensure `lead_created` notifications send emails even without DB configuration
- streamline public lead form notification logging

## Testing
- `php -l app/Controllers/Notification_processor.php`
- `php -l app/Models/Notifications_model.php`
- `php -l app/Controllers/Collect_leads.php`


------
https://chatgpt.com/codex/tasks/task_e_689f9661533c833291d05f6bacaa29a8