### PR TITLE
Add team member volume summary report for leads

### DIFF
--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2502,6 +2502,7 @@ $lang["open_tasks"] = "Open Objectives";
 $lang["completed_tasks"] = "Completed Objectives";
 
 $lang["team_members_summary"] = "Team members summary";
+$lang["team_members_volume_summary"] = "Team members volume summary";
 $lang["created_date_wise"] = "Created date wise";
 $lang["conversion_date_wise"] = "Conversion date wise";
 

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -2499,6 +2499,7 @@ $lang["open_tasks"] = "Open Tasks";
 $lang["completed_tasks"] = "Completed Tasks";
 
 $lang["team_members_summary"] = "Team members summary";
+$lang["team_members_volume_summary"] = "Team members volume summary";
 $lang["created_date_wise"] = "Created date wise";
 $lang["conversion_date_wise"] = "Conversion date wise";
 

--- a/app/Views/leads/reports/converted_to_client.php
+++ b/app/Views/leads/reports/converted_to_client.php
@@ -6,6 +6,7 @@
             <li class="title-tab"><h4 class="pl15 pt10 pr15"><?php echo app_lang("clients"); ?></h4></li>
             <li><a id="converted-to-client-button" role="presentation" data-bs-toggle="tab"  href="javascript:;" data-bs-target="#converted-to-client-tab"><?php echo app_lang("clients"); ?></a></li>
             <li><a role="presentation" data-bs-toggle="tab" href="<?php echo_uri("leads/team_members_summary"); ?>" data-bs-target="#team-members-summary-tab"><?php echo app_lang('team_members_summary'); ?></a></li>
+            <li><a role="presentation" data-bs-toggle="tab" href="<?php echo_uri("leads/team_members_volume_summary"); ?>" data-bs-target="#team-members-volume-summary-tab"><?php echo app_lang('team_members_volume_summary'); ?></a></li>
 
         </ul>
 
@@ -21,6 +22,7 @@
 
             </div>
             <div role="tabpanel" class="tab-pane fade" id="team-members-summary-tab"></div>
+            <div role="tabpanel" class="tab-pane fade" id="team-members-volume-summary-tab"></div>
         </div>
     </div>
 </div>

--- a/app/Views/leads/reports/team_members_volume_summary.php
+++ b/app/Views/leads/reports/team_members_volume_summary.php
@@ -1,0 +1,37 @@
+<div class="table-responsive">
+    <table id="team-members-volume-summary" class="display" width="100%">
+    </table>
+</div>
+
+<?php
+$columns = array(array("title" => app_lang("owner"), "class" => "all"));
+foreach ($lead_statuses as $status) {
+    $columns[] = array("title" => $status->title, "class" => "text-right");
+}
+$columns[] = array("title" => "Won %", "class" => "text-right all");
+
+$total_columns = count($columns);
+$print_columns = range(0, $total_columns - 1);
+?>
+
+<script type="text/javascript">
+
+    $(document).ready(function () {
+
+        $("#team-members-volume-summary").appTable({
+
+            source: '<?php echo_uri("leads/team_members_volume_summary_data") ?>',
+            rangeDatepicker: [{startDate: {name: "created_date_from", value: ""}, endDate: {name: "created_date_to", value: ""}, showClearButton: true, label: "<?php echo app_lang('created_date'); ?>", ranges: ['this_month', 'last_month', 'this_year', 'last_year', 'last_30_days', 'last_7_days']}],
+            filterDropdown: [
+                {name: "source_id", class: "w200", options: <?php echo $sources_dropdown; ?>},
+                {name: "label_id", class: "w200", options: <?php echo $labels_dropdown; ?>}
+            ],
+            columns: <?php echo json_encode($columns) ?>,
+            printColumns: <?php echo json_encode($print_columns); ?>,
+            pdfColumns: <?php echo json_encode($print_columns); ?>,
+            xlsColumns: <?php echo json_encode($print_columns); ?>
+        });
+    }
+    );
+</script>
+


### PR DESCRIPTION
## Summary
- add model method to aggregate custom volume field per owner/status
- introduce controller and view for team member volume summary report
- expose volume report in leads reports navigation and language strings

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/team_members_volume_summary.php`
- `php -l app/Views/leads/reports/converted_to_client.php`
- `php -l app/Language/english/default_lang.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7478f98e08332903aec2d4009c9af