### PR TITLE
Add totals to team volume summary

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1815,10 +1815,13 @@ class Leads extends Security_Controller {
         $won = 0;
         $lost = 0;
 
+        $row_total = 0;
+
         foreach ($lead_statuses as $status) {
             $total = get_array_value($status_total_array, $status->id);
             $total = $total ? $total : 0;
             $row_data[] = $total ? to_decimal_format($total) : 0;
+            $row_total += $total;
 
             if ($status->id == $won_status_id) {
                 $won = $total ? $total : 0;
@@ -1826,6 +1829,8 @@ class Leads extends Security_Controller {
                 $lost = $total ? $total : 0;
             }
         }
+
+        $row_data[] = $row_total ? to_decimal_format($row_total) : 0;
 
         $percent = ($won + $lost) ? round(($won / ($won + $lost)) * 100, 2) : 0;
         $row_data[] = $percent;

--- a/app/Views/leads/reports/team_members_volume_summary.php
+++ b/app/Views/leads/reports/team_members_volume_summary.php
@@ -8,10 +8,18 @@ $columns = array(array("title" => app_lang("owner"), "class" => "all"));
 foreach ($lead_statuses as $status) {
     $columns[] = array("title" => $status->title, "class" => "text-right");
 }
+
+$columns[] = array("title" => app_lang("total"), "class" => "text-right");
 $columns[] = array("title" => "Won %", "class" => "text-right all");
 
 $total_columns = count($columns);
 $print_columns = range(0, $total_columns - 1);
+
+$summation = array();
+for ($i = 1; $i <= count($lead_statuses); $i++) {
+    $summation[] = array("column" => $i, "dataType" => "number");
+}
+$summation[] = array("column" => count($lead_statuses) + 1, "dataType" => "number");
 ?>
 
 <script type="text/javascript">
@@ -29,7 +37,8 @@ $print_columns = range(0, $total_columns - 1);
             columns: <?php echo json_encode($columns) ?>,
             printColumns: <?php echo json_encode($print_columns); ?>,
             pdfColumns: <?php echo json_encode($print_columns); ?>,
-            xlsColumns: <?php echo json_encode($print_columns); ?>
+            xlsColumns: <?php echo json_encode($print_columns); ?>,
+            summation: <?php echo json_encode($summation); ?>
         });
     }
     );


### PR DESCRIPTION
## Summary
- add Total column and column summation to team member volume summary table
- calculate per-team-member totals across statuses for volume summary

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/team_members_volume_summary.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7604506c08332a3a260554e9fd1da