### PR TITLE
Add volume-by-status chart and stabilize lead graphs

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1533,7 +1533,7 @@ class Leads extends Security_Controller {
         $view_data["source_wise_labels"] = json_encode($source_wise_data['labels']);
         $view_data["source_wise_data"] = json_encode($source_wise_data['data']);
 
-        //prepare volume by source data
+        //prepare volume data options
         $volume_options = array(
             "start_date" => $start_date,
             "end_date" => $this->request->getPost("end_date"),
@@ -1542,6 +1542,20 @@ class Leads extends Security_Controller {
             "client_groups" => $this->allowed_client_groups
         );
 
+        //volume by status
+        $volume_status_rows = $this->Clients_model->get_volume_by_status($volume_options);
+
+        $volume_by_status_labels = array();
+        $volume_by_status_data = array();
+        foreach ($volume_status_rows as $row) {
+            $volume_by_status_labels[] = $row->status_title ? $row->status_title : app_lang('unknown');
+            $volume_by_status_data[] = $row->volume * 1;
+        }
+
+        $view_data["volume_by_status_labels"] = json_encode($volume_by_status_labels);
+        $view_data["volume_by_status_data"] = json_encode($volume_by_status_data);
+
+        //volume by source
         $volume_rows = $this->Clients_model->get_volume_by_source($volume_options);
 
         $volume_by_source_labels = array();

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1256,6 +1256,84 @@ function get_details($options = array()) {
         return $this->db->query($sql)->getResult();
     }
 
+    //get total volume grouped by lead status
+    function get_volume_by_status($options = array()) {
+        $clients_table = $this->db->prefixTable('clients');
+        $cf_table = $this->db->prefixTable('custom_field_values');
+        $lead_status_table = $this->db->prefixTable('lead_status');
+
+        $where = "";
+
+        $owner_id = $this->_get_clean_value($options, "owner_id");
+        if ($owner_id) {
+            $where .= " AND $clients_table.owner_id=$owner_id";
+        }
+
+        $group_id = $this->_get_clean_value($options, "group_id");
+        if ($group_id) {
+            $where .= " AND FIND_IN_SET('$group_id', $clients_table.group_ids)";
+        }
+
+        $account_type = $this->_get_clean_value($options, "account_type");
+        if ($account_type) {
+            $where .= " AND $clients_table.type='$account_type'";
+        }
+
+        $source_id = $this->_get_clean_value($options, "source_id");
+        if ($source_id) {
+            $where .= " AND $clients_table.lead_source_id='$source_id'";
+        }
+
+        $status_ids = get_array_value($options, "status_ids");
+        if ($status_ids && is_array($status_ids)) {
+            $status_ids = array_map('intval', $status_ids);
+            $where .= " AND $clients_table.lead_status_id IN(" . implode(',', $status_ids) . ")";
+        }
+
+        $start_date = $this->_get_clean_value($options, "start_date");
+        if ($start_date) {
+            $where .= " AND DATE($clients_table.created_date)>='$start_date'";
+        }
+        $end_date = $this->_get_clean_value($options, "end_date");
+        if ($end_date) {
+            $where .= " AND DATE($clients_table.created_date)<='$end_date'";
+        }
+
+        $ec_start_date = $this->_get_clean_value($options, "estimated_close_start_date");
+        if ($ec_start_date) {
+            $where .= " AND DATE(ec.value)>='$ec_start_date'";
+        }
+        $ec_end_date = $this->_get_clean_value($options, "estimated_close_end_date");
+        if ($ec_end_date) {
+            $where .= " AND DATE(ec.value)<='$ec_end_date'";
+        }
+
+        $closed_start_date = $this->_get_clean_value($options, "closed_start_date");
+        if ($closed_start_date) {
+            $where .= " AND DATE(cd.value)>='$closed_start_date'";
+        }
+        $closed_end_date = $this->_get_clean_value($options, "closed_end_date");
+        if ($closed_end_date) {
+            $where .= " AND DATE(cd.value)<='$closed_end_date'";
+        }
+
+        $client_groups = $this->_get_clean_value($options, "client_groups");
+        $where .= $this->prepare_allowed_client_groups_query($clients_table, $client_groups);
+
+        $sql = "SELECT $clients_table.lead_status_id, $lead_status_table.title AS status_title,
+                       SUM(IFNULL(volume.value,0)) AS volume
+                FROM $clients_table
+                LEFT JOIN $cf_table AS volume ON volume.custom_field_id=273 AND volume.related_to_type='clients' AND volume.related_to_id=$clients_table.id AND volume.deleted=0
+                LEFT JOIN $cf_table AS ec ON ec.custom_field_id=167 AND ec.related_to_type='clients' AND ec.related_to_id=$clients_table.id AND ec.deleted=0
+                LEFT JOIN $cf_table AS cd ON cd.custom_field_id=272 AND cd.related_to_type='clients' AND cd.related_to_id=$clients_table.id AND cd.deleted=0
+                LEFT JOIN $lead_status_table ON $lead_status_table.id=$clients_table.lead_status_id
+                WHERE $clients_table.deleted=0 AND $clients_table.is_lead=0 $where
+                GROUP BY $clients_table.lead_status_id
+                ORDER BY $lead_status_table.sort ASC";
+
+        return $this->db->query($sql)->getResult();
+    }
+
     function get_fill_the_funnel_leaderboard($options = array()) {
         $clients_table = $this->db->prefixTable('clients');
         $users_table = $this->db->prefixTable('users');

--- a/app/Views/clients/reports/volume_by_status_chart.php
+++ b/app/Views/clients/reports/volume_by_status_chart.php
@@ -1,15 +1,15 @@
-<div id="volume-by-source-chart-container" class="row">
+<div id="volume-by-status-chart-container" class="row">
     <div class="text-end mb-3">
-        <button id="download-volume-by-source-pdf" class="btn btn-default">
+        <button id="download-volume-by-status-pdf" class="btn btn-default">
             <i data-feather="download" class="icon-16"></i> <?php echo app_lang('download_pdf'); ?>
         </button>
     </div>
-    <style>#volume-by-source-chart{height:550px!important;}</style>
+    <style>#volume-by-status-chart{height:550px!important;}</style>
     <div class="col-md-12">
         <div class="card">
             <div class="card-body">
-                <h4 class="mb15"><?php echo app_lang('volume'); ?></h4>
-                <canvas id="volume-by-source-chart" style="width:100%; height:350px;"></canvas>
+                <h4 class="mb15"><?php echo app_lang('volume'); ?> by <?php echo app_lang('lead_status'); ?></h4>
+                <canvas id="volume-by-status-chart" style="width:100%; height:350px;"></canvas>
             </div>
         </div>
     </div>
@@ -17,7 +17,7 @@
 
 <script type="text/javascript">
     $(document).ready(function () {
-        var ctx = document.getElementById("volume-by-source-chart");
+        var ctx = document.getElementById("volume-by-status-chart");
         new Chart(ctx, {
             type: 'bar',
             data: {
@@ -45,10 +45,10 @@
             }
         });
 
-        $("#download-volume-by-source-pdf").on("click", function () {
+        $("#download-volume-by-status-pdf").on("click", function () {
             var button = this;
             button.style.display = 'none';
-            html2canvas(document.getElementById('volume-by-source-chart-container')).then(function (canvas) {
+            html2canvas(document.getElementById('volume-by-status-chart-container')).then(function (canvas) {
                 var imgData = canvas.toDataURL('image/png');
                 var pdf = new jspdf.jsPDF();
                 var width = pdf.internal.pageSize.getWidth();

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -50,6 +50,7 @@
             </div>
         </div>
     </div>
+    <?php echo view("clients/reports/volume_by_status_chart", array("labels" => $volume_by_status_labels, "volume_data" => $volume_by_status_data)); ?>
     <?php echo view("clients/reports/volume_by_source_chart", array("labels" => $volume_by_source_labels, "volume_data" => $volume_by_source_data)); ?>
 </div>
 
@@ -57,7 +58,9 @@
 
 <script type="text/javascript">
     $(document).ready(function () {
-        Chart.plugins.register(ChartDataLabels);
+        if (window.ChartDataLabels && Chart && Chart.plugins) {
+            Chart.plugins.register(ChartDataLabels);
+        }
 
         new Chart(document.getElementById("leads-day-wise-chart"), {
             type: 'line',


### PR DESCRIPTION
## Summary
- Add database query for grouping volume by lead status
- Display volume-by-status chart above volume-by-source chart
- Guard chart plugin registration to avoid blank page and fix missing style tag

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`
- `php -l app/Views/clients/reports/volume_by_source_chart.php`
- `php -l app/Views/clients/reports/volume_by_status_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_68a764b778008332b4dd4d6e43f6521f