### PR TITLE
Color volume chart by status

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1547,13 +1547,16 @@ class Leads extends Security_Controller {
 
         $volume_by_status_labels = array();
         $volume_by_status_data = array();
+        $volume_by_status_colors = array();
         foreach ($volume_status_rows as $row) {
             $volume_by_status_labels[] = $row->status_title ? $row->status_title : app_lang('unknown');
             $volume_by_status_data[] = $row->volume * 1;
+            $volume_by_status_colors[] = $row->status_color ? $row->status_color : '#808080';
         }
 
         $view_data["volume_by_status_labels"] = json_encode($volume_by_status_labels);
         $view_data["volume_by_status_data"] = json_encode($volume_by_status_data);
+        $view_data["volume_by_status_colors"] = json_encode($volume_by_status_colors);
 
         //volume by source
         $volume_rows = $this->Clients_model->get_volume_by_source($volume_options);

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1321,6 +1321,7 @@ function get_details($options = array()) {
         $where .= $this->prepare_allowed_client_groups_query($clients_table, $client_groups);
 
         $sql = "SELECT $clients_table.lead_status_id, $lead_status_table.title AS status_title,
+                       $lead_status_table.color AS status_color,
                        SUM(IFNULL(volume.value,0)) AS volume
                 FROM $clients_table
                 LEFT JOIN $cf_table AS volume ON volume.custom_field_id=273 AND volume.related_to_type='clients' AND volume.related_to_id=$clients_table.id AND volume.deleted=0

--- a/app/Views/clients/reports/volume_by_status_chart.php
+++ b/app/Views/clients/reports/volume_by_status_chart.php
@@ -25,7 +25,9 @@
                 datasets: [{
                     label: '<?php echo app_lang('volume'); ?>',
                     data: <?php echo $volume_data; ?>,
-                    backgroundColor: '#3B81F6'
+                    backgroundColor: <?php echo $status_colors; ?>,
+                    borderColor: <?php echo $status_colors; ?>,
+                    borderWidth: 1
                 }]
             },
             options: {

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -50,7 +50,7 @@
             </div>
         </div>
     </div>
-    <?php echo view("clients/reports/volume_by_status_chart", array("labels" => $volume_by_status_labels, "volume_data" => $volume_by_status_data)); ?>
+    <?php echo view("clients/reports/volume_by_status_chart", array("labels" => $volume_by_status_labels, "volume_data" => $volume_by_status_data, "status_colors" => $volume_by_status_colors)); ?>
     <?php echo view("clients/reports/volume_by_source_chart", array("labels" => $volume_by_source_labels, "volume_data" => $volume_by_source_data)); ?>
 </div>
 


### PR DESCRIPTION
## Summary
- display volume by status chart using each status's color
- wire up status colors from server-side data

## Testing
- `php -l app/Models/Clients_model.php`
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/clients/reports/volume_by_status_chart.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_68a76ac166188332b5a6ed622d9b97aa