### PR TITLE
Add clients expanded report view

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -97,6 +97,7 @@ if (!function_exists('get_reports_topbar')) {
             $reports_menu[] = array("name" => "opportunities_graphs", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
             $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
             $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
+            $reports_menu[] = array("name" => "show_expanded_view", "url" => "clients/show_expanded_view", "class" => "grid", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2791,6 +2791,7 @@ $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderbo
 
 $lang["opportunities_graphs"] = "Opportunities Graphs";
 $lang["opportunity_data_reports"] = "Opportunity Data Reports";
+$lang["show_expanded_view"] = "Show Expanded View";
 $lang["opportunity_status"] = "Status";
 $lang['show_in_public_form'] = 'Show in public form';
 $lang['full_form'] = 'Full form';

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -152,7 +152,11 @@ function get_details($options = array()) {
         "owner_name" => "owner_details.owner_name",
         "primary_contact" => "primary_contact",
         "client_groups" => "client_groups",
-        "lead_source_title" => "lead_source_title"
+        "lead_source_title" => "lead_source_title",
+        "address" => $clients_table . ".address",
+        "city" => $clients_table . ".city",
+        "state" => $clients_table . ".state",
+        "zip" => $clients_table . ".zip"
     );
 
     $order_by = get_array_value($available_order_by_list, $this->_get_clean_value($options, "order_by"));

--- a/app/Views/clients/reports/show_expanded_view.php
+++ b/app/Views/clients/reports/show_expanded_view.php
@@ -1,0 +1,74 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card border-top-0 rounded-top-0">
+        <div class="table-responsive">
+            <table id="clients-expanded-table" class="display" width="100%"></table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        var showOptions = <?php echo json_encode($can_edit_clients); ?>;
+        var quick_filters_dropdown = <?php echo view("clients/quick_filters_dropdown"); ?>;
+        var type_dropdown = [
+            {id: "", text: "- <?php echo app_lang('type'); ?> -"},
+            {id: "person", text: "<?php echo app_lang('person'); ?>"},
+            {id: "organization", text: "<?php echo app_lang('organization'); ?>"}
+        ];
+
+        var columns = [
+            {title: "<?php echo app_lang('id'); ?>", class: "text-center w50 desktop", order_by: "id"},
+            {title: "<?php echo app_lang('name'); ?>", class: "all", order_by: "company_name"},
+            {title: "<?php echo app_lang('primary_contact'); ?>", order_by: "primary_contact"},
+            {title: "<?php echo app_lang('address'); ?>", order_by: "address"},
+            {title: "<?php echo app_lang('city'); ?>", order_by: "city"},
+            {title: "<?php echo app_lang('state'); ?>", order_by: "state"},
+            {title: "<?php echo app_lang('zip'); ?>", order_by: "zip"},
+            {title: "<?php echo app_lang('phone'); ?>", order_by: "phone"},
+            {title: "<?php echo app_lang('type'); ?>", order_by: "account_type"},
+            {title: "Created Date", order_by: "created_date"},
+            {title: "<?php echo app_lang('client_groups'); ?>", order_by: "client_groups"},
+            {title: "<?php echo app_lang('owner'); ?>", order_by: "client_owner"},
+            {title: "<?php echo app_lang('source'); ?>", order_by: "lead_source_title"},
+            {title: "<?php echo app_lang('status'); ?>", class: "text-center w100", order_by: "status"},
+            {title: "Probability %", class: "text-center w100"},
+            {title: "Potential Margin", class: "text-right w100"},
+            {title: "Weighted Forecast", class: "text-right w100"}
+        ];
+
+        <?php if (!empty($custom_field_headers)) { ?>
+            try {
+                var customColumns = [<?php echo $custom_field_headers; ?>];
+                columns = columns.concat(customColumns.filter(function (col) { return col && typeof col === 'object'; }));
+            } catch (e) { }
+        <?php } ?>
+
+        columns.push({title: '<i data-feather="menu" class="icon-16"></i>', class: "text-center option w100", visible: showOptions});
+
+        $("#clients-expanded-table").appTable({
+            source: '<?php echo_uri("clients/show_expanded_view_list_data") ?>',
+            serverSide: true,
+            filterDropdown: [
+                {name: "quick_filter", class: "w200", options: quick_filters_dropdown},
+                <?php if ($login_user->is_admin || get_array_value($login_user->permissions, "client") === "all") { ?>
+                    {name: "owner_id", class: "w200", options: <?php echo $team_members_dropdown; ?>},
+                <?php } ?>
+                {name: "group_id", class: "w200", options: <?php echo $groups_dropdown; ?>},
+                {name: "account_type", class: "w200", options: type_dropdown},
+                {name: "status", class: "w200", options: <?php echo view("clients/client_statuses"); ?>},
+                {name: "source_id", class: "w200", options: <?php echo view("leads/lead_sources", array("lead_sources" => $lead_sources)); ?>},
+                <?php echo $custom_field_filters; ?>
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true},
+                {startDate: {name: "estimated_close_start_date", value: ""}, endDate: {name: "estimated_close_end_date", value: ""}, label: "Estimated Close", showClearButton: true},
+                {startDate: {name: "closed_start_date", value: ""}, endDate: {name: "closed_end_date", value: ""}, label: "Closed Date", showClearButton: true}
+            ],
+            columns: columns,
+            printColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16], '<?php echo $custom_field_headers; ?>'),
+            xlsColumns: combineCustomFieldsColumns([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16], '<?php echo $custom_field_headers; ?>')
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add clients expanded report view listing addresses
- include link in reports top bar and translation string
- support sorting by address fields

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Helpers/reports_helper.php`
- `php -l app/Language/english/custom_lang.php`
- `php -l app/Views/clients/reports/show_expanded_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a76e098d20833280eacc076443de3f