### PR TITLE
Add expanded view button to clients page

### DIFF
--- a/app/Views/clients/index.php
+++ b/app/Views/clients/index.php
@@ -9,6 +9,11 @@
                     <?php
                     if ($can_edit_clients) {
                         echo modal_anchor(get_uri("labels/modal_form"), "<i data-feather='tag' class='icon-16'></i> " . app_lang('manage_labels'), array("class" => "btn btn-default", "title" => app_lang('manage_labels'), "data-post-type" => "client"));
+                    }
+
+                    echo anchor(get_uri("clients/show_expanded_view"), "<i data-feather='grid' class='icon-16'></i> " . app_lang('show_expanded_view'), array("class" => "btn btn-default", "title" => app_lang('show_expanded_view')));
+
+                    if ($can_edit_clients) {
                         echo modal_anchor(get_uri("clients/import_modal_form"), "<i data-feather='upload' class='icon-16'></i> " . app_lang('import_clients'), array("class" => "btn btn-default", "title" => app_lang('import_clients'), "id" => "import-btn"));
                         echo modal_anchor(get_uri("clients/modal_form"), "<i data-feather='plus-circle' class='icon-16'></i> " . app_lang('add_client'), array("class" => "btn btn-default", "title" => app_lang('add_client')));
                     }


### PR DESCRIPTION
## Summary
- add Show Expanded View button beside Manage Labels on Clients page

## Testing
- `php -l app/Views/clients/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7713d9eac83328dd570dc613955fd