### PR TITLE
Fix non-responsive show expanded view button and add return link

### DIFF
--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2792,6 +2792,7 @@ $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderbo
 $lang["opportunities_graphs"] = "Opportunities Graphs";
 $lang["opportunity_data_reports"] = "Opportunity Data Reports";
 $lang["show_expanded_view"] = "Show Expanded View";
+$lang["show_normal_view"] = "Show Normal View";
 $lang["opportunity_status"] = "Status";
 $lang['show_in_public_form'] = 'Show in public form';
 $lang['full_form'] = 'Full form';

--- a/app/Views/clients/index.php
+++ b/app/Views/clients/index.php
@@ -4,23 +4,23 @@
             <li><a role="presentation" data-bs-toggle="tab" href="javascript:;" data-bs-target="#overview"><?php echo app_lang('overview'); ?></a></li>
             <li><a role="presentation" data-bs-toggle="tab" href="<?php echo_uri("clients/clients_list/"); ?>" data-bs-target="#clients_list"><?php echo app_lang('clients'); ?></a></li>
             <li><a role="presentation" data-bs-toggle="tab" href="<?php echo_uri("clients/contacts/"); ?>" data-bs-target="#contacts"><?php echo app_lang('contacts'); ?></a></li>
-            <div class="tab-title clearfix no-border">
-                <div class="title-button-group">
-                    <?php
-                    if ($can_edit_clients) {
-                        echo modal_anchor(get_uri("labels/modal_form"), "<i data-feather='tag' class='icon-16'></i> " . app_lang('manage_labels'), array("class" => "btn btn-default", "title" => app_lang('manage_labels'), "data-post-type" => "client"));
-                    }
-
-                    echo anchor(get_uri("clients/show_expanded_view"), "<i data-feather='grid' class='icon-16'></i> " . app_lang('show_expanded_view'), array("class" => "btn btn-default", "title" => app_lang('show_expanded_view')));
-
-                    if ($can_edit_clients) {
-                        echo modal_anchor(get_uri("clients/import_modal_form"), "<i data-feather='upload' class='icon-16'></i> " . app_lang('import_clients'), array("class" => "btn btn-default", "title" => app_lang('import_clients'), "id" => "import-btn"));
-                        echo modal_anchor(get_uri("clients/modal_form"), "<i data-feather='plus-circle' class='icon-16'></i> " . app_lang('add_client'), array("class" => "btn btn-default", "title" => app_lang('add_client')));
-                    }
-                    ?>
-                </div>
-            </div>
         </ul>
+        <div class="tab-title clearfix no-border">
+            <div class="title-button-group">
+                <?php
+                if ($can_edit_clients) {
+                    echo modal_anchor(get_uri("labels/modal_form"), "<i data-feather='tag' class='icon-16'></i> " . app_lang('manage_labels'), array("class" => "btn btn-default", "title" => app_lang('manage_labels'), "data-post-type" => "client"));
+                }
+
+                echo anchor(get_uri("clients/show_expanded_view"), "<i data-feather='grid' class='icon-16'></i> " . app_lang('show_expanded_view'), array("class" => "btn btn-default", "title" => app_lang('show_expanded_view')));
+
+                if ($can_edit_clients) {
+                    echo modal_anchor(get_uri("clients/import_modal_form"), "<i data-feather='upload' class='icon-16'></i> " . app_lang('import_clients'), array("class" => "btn btn-default", "title" => app_lang('import_clients'), "id" => "import-btn"));
+                    echo modal_anchor(get_uri("clients/modal_form"), "<i data-feather='plus-circle' class='icon-16'></i> " . app_lang('add_client'), array("class" => "btn btn-default", "title" => app_lang('add_client')));
+                }
+                ?>
+            </div>
+        </div>
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane fade" id="overview">
                 <?php echo view("clients/overview/index"); ?>

--- a/app/Views/clients/reports/show_expanded_view.php
+++ b/app/Views/clients/reports/show_expanded_view.php
@@ -1,6 +1,11 @@
 <?php echo get_reports_topbar(); ?>
 
 <div id="page-content" class="page-wrapper clearfix">
+    <div class="page-title clearfix">
+        <div class="title-button-group">
+            <?php echo anchor(get_uri("clients"), "<i data-feather='list' class='icon-16'></i> " . app_lang('show_normal_view'), array("class" => "btn btn-default", "title" => app_lang('show_normal_view'))); ?>
+        </div>
+    </div>
     <div class="card border-top-0 rounded-top-0">
         <div class="table-responsive">
             <table id="clients-expanded-table" class="display" width="100%"></table>


### PR DESCRIPTION
## Summary
- Ensure the **Show Expanded View** button on the clients page works by moving it outside the AJAX tab container.
- Add a **Show Normal View** button on the expanded view page for returning to the standard clients view.
- Provide English translation for the new "Show Normal View" label.

## Testing
- `php -l app/Views/clients/index.php`
- `php -l app/Views/clients/reports/show_expanded_view.php`
- `php -l app/Language/english/custom_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_68a77318c7b0833288423740f0b864f2