### PR TITLE
Remove expanded view from reports navigation

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -97,7 +97,6 @@ if (!function_exists('get_reports_topbar')) {
             $reports_menu[] = array("name" => "opportunities_graphs", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
             $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
             $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
-            $reports_menu[] = array("name" => "show_expanded_view", "url" => "clients/show_expanded_view", "class" => "grid", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Views/clients/reports/show_expanded_view.php
+++ b/app/Views/clients/reports/show_expanded_view.php
@@ -1,5 +1,3 @@
-<?php echo get_reports_topbar(); ?>
-
 <div id="page-content" class="page-wrapper clearfix">
     <div class="page-title clearfix">
         <div class="title-button-group">


### PR DESCRIPTION
## Summary
- Drop reports topbar from expanded client view to avoid permission errors
- Remove expanded view entry from reports helper so it no longer shows in the reports navigation

## Testing
- `php -l app/Views/clients/reports/show_expanded_view.php`
- `php -l app/Helpers/reports_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68a775ba3dfc8332a72285095a16609e