### PR TITLE
Hide reports menu for unauthorized users

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -14,6 +14,7 @@ if (!function_exists('get_reports_topbar')) {
     function get_reports_topbar($return_array = false) {
         $ci = new Security_Controller(false);
         $permissions = $ci->login_user->permissions;
+        $reports_menu = array();
 
         $access_invoice = get_array_value($permissions, "invoice");
         $access_expense = get_array_value($permissions, "expense");

--- a/app/Libraries/Left_menu.php
+++ b/app/Libraries/Left_menu.php
@@ -199,23 +199,26 @@ class Left_menu {
                 $show_expenses_menu = true;
             }
 
-            $sidebar_menu["reports"] = array(
-                "name" => "reports",
-                "url" => "reports/index",
-                "class" => "pie-chart",
-                "sub_pages" => array(
-                    "invoices/invoices_summary",
-                    "orders/orders_summary",
-                    "projects/all_timesheets",
-                    "expenses/income_vs_expenses",
-                    "invoice_payments/payments_summary",
-                    "expenses/summary",
-                    "projects/team_members_summary",
-                    "leads/converted_to_client_report",
-                    "clients/clients_report",
-                    "tickets/tickets_chart_report"
-                )
-            );
+            $reports_menu = get_reports_topbar(true);
+            if (!empty($reports_menu)) {
+                $sidebar_menu["reports"] = array(
+                    "name" => "reports",
+                    "url" => "reports/index",
+                    "class" => "pie-chart",
+                    "sub_pages" => array(
+                        "invoices/invoices_summary",
+                        "orders/orders_summary",
+                        "projects/all_timesheets",
+                        "expenses/income_vs_expenses",
+                        "invoice_payments/payments_summary",
+                        "expenses/summary",
+                        "projects/team_members_summary",
+                        "leads/converted_to_client_report",
+                        "clients/clients_report",
+                        "tickets/tickets_chart_report"
+                    )
+                );
+            }
 
 
             $access_file_manager = true;


### PR DESCRIPTION
## Summary
- Show left menu "Reports" only when user has access to at least one report
- Initialize reports menu array to avoid undefined variable notices

## Testing
- `php -l app/Libraries/Left_menu.php`
- `php -l app/Helpers/reports_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68a777fbf86083328b157a4af70cfa29