### PR TITLE
Add Google Places address autocomplete

### DIFF
--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -73,4 +73,8 @@
             $(this).trigger("submit");
         });
     });
-</script>    
+</script>
+<script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+<script>
+    initAddressAutocomplete('#client-form');
+</script>

--- a/app/Views/includes/custom_head.php
+++ b/app/Views/includes/custom_head.php
@@ -1,4 +1,7 @@
 
+<?php $googleMapsApiKey = getenv('GOOGLE_MAPS_API_KEY'); ?>
+<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places"></script>
+
 <script>
 window.addAppTableDisplayOption = 10000;
 </script>

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -30,4 +30,8 @@
             $("#company_name").focus();
         }, 200);
     });
-</script>    
+</script>
+<script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+<script>
+    initAddressAutocomplete('#lead-form');
+</script>

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -1,0 +1,73 @@
+// Initialize Google Places Autocomplete for address fields
+(function (window) {
+    window.initAddressAutocomplete = function (formSelector) {
+        var $form = $(formSelector);
+        if (!$form.length || typeof google === "undefined" || !google.maps || !google.maps.places) {
+            return;
+        }
+
+        var $address = $form.find('#address');
+        if (!$address.length) {
+            return;
+        }
+
+        var autocomplete = new google.maps.places.Autocomplete($address[0], { types: ['address'] });
+
+        var fields = ['address', 'city', 'state', 'zip', 'country'];
+        fields.forEach(function (field) {
+            $form.find('#' + field).attr('autocomplete', 'off');
+        });
+
+        autocomplete.addListener('place_changed', function () {
+            var place = autocomplete.getPlace();
+            if (!place.address_components) {
+                return;
+            }
+
+            var address = '';
+            var city = '';
+            var state = '';
+            var zip = '';
+            var country = '';
+
+            place.address_components.forEach(function (component) {
+                var types = component.types;
+                if (types.indexOf('street_number') > -1) {
+                    address = component.long_name + (address ? ' ' + address : '');
+                }
+                if (types.indexOf('route') > -1) {
+                    address = address ? address + ' ' + component.long_name : component.long_name;
+                }
+                if (types.indexOf('locality') > -1) {
+                    city = component.long_name;
+                }
+                if (types.indexOf('administrative_area_level_1') > -1) {
+                    state = component.short_name;
+                }
+                if (types.indexOf('postal_code') > -1) {
+                    zip = component.long_name;
+                }
+                if (types.indexOf('country') > -1) {
+                    country = component.long_name;
+                }
+            });
+
+            if (address) {
+                $form.find('#address').val(address);
+            }
+            if (city) {
+                $form.find('#city').val(city);
+            }
+            if (state) {
+                $form.find('#state').val(state);
+            }
+            if (zip) {
+                $form.find('#zip').val(zip);
+            }
+            if (country) {
+                $form.find('#country').val(country);
+            }
+        });
+    };
+})(window);
+


### PR DESCRIPTION
## Summary
- load Google Maps Places API via configurable key
- add helper to populate address fields from Places suggestions
- wire up address autocomplete on client and lead forms

## Testing
- `php -l app/Views/includes/custom_head.php`
- `php -l app/Views/clients/modal_form.php`
- `php -l app/Views/leads/modal_form.php`
- `node --check assets/js/google_address_autocomplete.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68ac840d6e888332920a91b846682ddd