### PR TITLE
Fix Google Autocomplete by switching address fields to inputs

### DIFF
--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -126,7 +126,7 @@
         <label for="address" class="<?php echo $label_column; ?>"><?php echo app_lang('address'); ?></label>
         <div class="<?php echo $field_column; ?>">
             <?php
-            echo form_textarea(array(
+            echo form_input(array(
                 "id" => "address",
                 "name" => "address",
                 "value" => $model_info->address ? $model_info->address : "",

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -4,7 +4,7 @@
     <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" >
     <input type="text" name="last_name" id="last_name" placeholder="<?php echo app_lang('last_name'); ?>" required="required">
     <input type="email" name="email" id="email" placeholder="<?php echo app_lang('email'); ?>" autocomplete="off">
-    <textarea name="address" cols="40" rows="10" id="address" placeholder="<?php echo app_lang('address'); ?>"></textarea>
+    <input type="text" name="address" id="address" placeholder="<?php echo app_lang('address'); ?>">
     <input type="text" name="city" id="city" placeholder="<?php echo app_lang('city'); ?>">
     <input type="text" name="state" id="state" placeholder="<?php echo app_lang('state'); ?>">
     <input type="text" name="zip" id="zip" placeholder="<?php echo app_lang('zip'); ?>">

--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -118,7 +118,7 @@
         <label for="address" class="<?php echo $label_column; ?>"><?php echo app_lang('address'); ?></label>
         <div class="<?php echo $field_column; ?>">
             <?php
-            echo form_textarea(array(
+            echo form_input(array(
                 "id" => "address",
                 "name" => "address",
                 "value" => $model_info->address ? $model_info->address : "",


### PR DESCRIPTION
## Summary
- replace address textareas with text inputs so Google Places Autocomplete accepts them
- adjust collect_leads form to use an input for address

## Testing
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Views/leads/lead_form_fields.php`
- `php -l app/Views/collect_leads/lead_html_form_code.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac8b361ffc83328b744277311e9693