### PR TITLE
Fix MutationObserver error in address autocomplete

### DIFF
--- a/assets/js/select2/select2.js
+++ b/assets/js/select2/select2.js
@@ -1145,10 +1145,13 @@ the specific language governing permissions and limitations under the Apache Lic
             observer = window.MutationObserver || window.WebKitMutationObserver|| window.MozMutationObserver;
             if (observer !== undefined) {
                 if (this.propertyObserver) { delete this.propertyObserver; this.propertyObserver = null; }
-                this.propertyObserver = new observer(function (mutations) {
-                    $.each(mutations, self._sync);
-                });
-                this.propertyObserver.observe(el.get(0), { attributes:true, subtree:false });
+                var target = el.get(0);
+                if (target && target.nodeType) {
+                    this.propertyObserver = new observer(function (mutations) {
+                        $.each(mutations, self._sync);
+                    });
+                    this.propertyObserver.observe(target, { attributes:true, subtree:false });
+                }
             }
         },
 


### PR DESCRIPTION
## Summary
- Guard MutationObserver usage in Select2 to avoid crashes when element is missing or invalid
- Leave generated `app.all.js` untouched

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d85fd6083329cdd85354199b0cd