### PR TITLE
Fix MutationObserver initialization for address autocomplete

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -71,3 +71,37 @@
     };
 })(window);
 
+// Monitor DOM changes safely and re-initialize address autocompletion
+(function () {
+    var lastHref = window.location.href;
+
+    function initForms() {
+        if (typeof window.initAddressAutocomplete === "function") {
+            window.initAddressAutocomplete("#lead-form");
+            window.initAddressAutocomplete("#client-form");
+        }
+    }
+
+    function startObserver() {
+        var observer = new MutationObserver(function () {
+            if (window.location.href !== lastHref) {
+                lastHref = window.location.href;
+                initForms();
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    if (document.body) {
+        startObserver();
+    } else {
+        window.addEventListener("DOMContentLoaded", startObserver);
+    }
+
+    initForms();
+})();
+


### PR DESCRIPTION
## Summary
- Safely set up MutationObserver to monitor DOM changes and re-initialize Google address autocomplete on leads and client forms
- Guard observer start until `document.body` is available to prevent runtime errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac95314d4483328fcc4a830f31ea57