### PR TITLE
Guard MutationObserver target in address autocomplete

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -83,6 +83,11 @@
     }
 
     function startObserver() {
+        var target = document.body;
+        if (!target || !(target instanceof Node)) {
+            return;
+        }
+
         var observer = new MutationObserver(function () {
             if (window.location.href !== lastHref) {
                 lastHref = window.location.href;
@@ -90,16 +95,20 @@
             }
         });
 
-        observer.observe(document.body, {
-            childList: true,
-            subtree: true
-        });
+        try {
+            observer.observe(target, {
+                childList: true,
+                subtree: true
+            });
+        } catch (e) {
+            console.error("MutationObserver failed", e);
+        }
     }
 
-    if (document.body) {
-        startObserver();
-    } else {
+    if (document.readyState === "loading") {
         window.addEventListener("DOMContentLoaded", startObserver);
+    } else {
+        startObserver();
     }
 
     initForms();


### PR DESCRIPTION
## Summary
- Avoid `MutationObserver` errors when the body element is missing
- Defer observer init until DOM is ready and handle failures gracefully

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97ab482883328cac6bfc21e8be35