### PR TITLE
Prevent MutationObserver errors in Google address autocomplete

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -84,11 +84,18 @@
 
     function startObserver() {
         var target = document.body;
-        if (!target || !(target instanceof Node)) {
+
+        // Ensure a valid DOM node is available before observing
+        if (!target || typeof target !== "object" || !target.nodeType) {
             return;
         }
 
-        var observer = new MutationObserver(function () {
+        var MutationObs = window.MutationObserver || window.WebKitMutationObserver || window.MozMutationObserver;
+        if (!MutationObs) {
+            return;
+        }
+
+        var observer = new MutationObs(function () {
             if (window.location.href !== lastHref) {
                 lastHref = window.location.href;
                 initForms();


### PR DESCRIPTION
## Summary
- guard MutationObserver setup to ensure a valid DOM node is observed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac992410148332bc40d716761cd775