### PR TITLE
Refactor address autocomplete initialization

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -1,72 +1,78 @@
 // Initialize Google Places Autocomplete for address fields
 (function (window) {
-    window.initAddressAutocomplete = function (formSelector) {
-        var $form = $(formSelector);
-        if (!$form.length || typeof google === "undefined" || !google.maps || !google.maps.places) {
+    window.initAddressAutocomplete = function (form) {
+        var $forms = $(form);
+        if (!$forms.length || typeof google === "undefined" || !google.maps || !google.maps.places) {
             return;
         }
 
-        var $address = $form.find('#address');
-        if (!$address.length) {
-            return;
-        }
-
-        var autocomplete = new google.maps.places.Autocomplete($address[0], { types: ['address'] });
-
-        var fields = ['address', 'city', 'state', 'zip', 'country'];
-        fields.forEach(function (field) {
-            $form.find('#' + field).attr('autocomplete', 'off');
-        });
-
-        autocomplete.addListener('place_changed', function () {
-            var place = autocomplete.getPlace();
-            if (!place.address_components) {
+        $forms.each(function () {
+            var $form = $(this);
+            var $addresses = $form.find('#address');
+            if (!$addresses.length) {
                 return;
             }
 
-            var address = '';
-            var city = '';
-            var state = '';
-            var zip = '';
-            var country = '';
+            $addresses.each(function () {
+                var $address = $(this);
+                var autocomplete = new google.maps.places.Autocomplete($address[0], { types: ['address'] });
 
-            place.address_components.forEach(function (component) {
-                var types = component.types;
-                if (types.indexOf('street_number') > -1) {
-                    address = component.long_name + (address ? ' ' + address : '');
-                }
-                if (types.indexOf('route') > -1) {
-                    address = address ? address + ' ' + component.long_name : component.long_name;
-                }
-                if (types.indexOf('locality') > -1) {
-                    city = component.long_name;
-                }
-                if (types.indexOf('administrative_area_level_1') > -1) {
-                    state = component.short_name;
-                }
-                if (types.indexOf('postal_code') > -1) {
-                    zip = component.long_name;
-                }
-                if (types.indexOf('country') > -1) {
-                    country = component.long_name;
-                }
+                var fields = ['address', 'city', 'state', 'zip', 'country'];
+                fields.forEach(function (field) {
+                    $form.find('#' + field).attr('autocomplete', 'off');
+                });
+
+                autocomplete.addListener('place_changed', function () {
+                    var place = autocomplete.getPlace();
+                    if (!place.address_components) {
+                        return;
+                    }
+
+                    var address = '';
+                    var city = '';
+                    var state = '';
+                    var zip = '';
+                    var country = '';
+
+                    place.address_components.forEach(function (component) {
+                        var types = component.types;
+                        if (types.indexOf('street_number') > -1) {
+                            address = component.long_name + (address ? ' ' + address : '');
+                        }
+                        if (types.indexOf('route') > -1) {
+                            address = address ? address + ' ' + component.long_name : component.long_name;
+                        }
+                        if (types.indexOf('locality') > -1) {
+                            city = component.long_name;
+                        }
+                        if (types.indexOf('administrative_area_level_1') > -1) {
+                            state = component.short_name;
+                        }
+                        if (types.indexOf('postal_code') > -1) {
+                            zip = component.long_name;
+                        }
+                        if (types.indexOf('country') > -1) {
+                            country = component.long_name;
+                        }
+                    });
+
+                    if (address) {
+                        $form.find('#address').val(address);
+                    }
+                    if (city) {
+                        $form.find('#city').val(city);
+                    }
+                    if (state) {
+                        $form.find('#state').val(state);
+                    }
+                    if (zip) {
+                        $form.find('#zip').val(zip);
+                    }
+                    if (country) {
+                        $form.find('#country').val(country);
+                    }
+                });
             });
-
-            if (address) {
-                $form.find('#address').val(address);
-            }
-            if (city) {
-                $form.find('#city').val(city);
-            }
-            if (state) {
-                $form.find('#state').val(state);
-            }
-            if (zip) {
-                $form.find('#zip').val(zip);
-            }
-            if (country) {
-                $form.find('#country').val(country);
-            }
         });
     };
 })(window);
@@ -75,11 +81,16 @@
 (function () {
     var lastHref = window.location.href;
 
-    function initForms() {
-        if (typeof window.initAddressAutocomplete === "function") {
-            window.initAddressAutocomplete("#lead-form");
-            window.initAddressAutocomplete("#client-form");
+    function initForms(root) {
+        if (typeof window.initAddressAutocomplete !== "function") {
+            return;
         }
+        var $root = root ? $(root) : $(document);
+        $root.find('#lead-form, #client-form')
+            .add($root.filter('#lead-form, #client-form'))
+            .each(function () {
+                window.initAddressAutocomplete(this);
+            });
     }
 
     function startObserver() {
@@ -119,7 +130,9 @@
     }
     // Re-initialize autocomplete when Bootstrap modals are shown
     if (typeof $ === 'function' && $.fn && $.fn.modal) {
-        $(document).on('shown.bs.modal', initForms);
+        $(document).on('shown.bs.modal', function (e) {
+            initForms(e.target);
+        });
     }
 
     initForms();


### PR DESCRIPTION
## Summary
- Expand address autocomplete initializer to handle multiple forms and address fields
- Automatically locate and initialize lead and client forms within any DOM context
- Ensure forms inside Bootstrap modals are initialized when shown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f9646a48332bcb2e4a2e3cd61f0