### PR TITLE
Remove company name autofocus and focus after modal shown

### DIFF
--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -43,7 +43,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));
@@ -63,7 +62,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));

--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -61,9 +61,13 @@
                 }
             }
         });
-        setTimeout(function () {
+        var $modal = $("#client-form").closest(".modal");
+        $modal.on("shown.bs.modal", function () {
             $("#company_name").focus();
-        }, 200);
+        });
+        if ($modal.hasClass("show")) {
+            $("#company_name").focus();
+        }
 
         //save and open add new contact member modal
         window.showAddNewModal = false;

--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -41,7 +41,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));
@@ -61,7 +60,6 @@
                     "value" => $model_info->company_name,
                     "class" => "form-control company_name_input_section",
                     "placeholder" => app_lang('company_name'),
-                    "autofocus" => true,
                     "data-rule-required" => true,
                     "data-msg-required" => app_lang("field_required"),
                 ));

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -26,9 +26,13 @@
                 }
             }
         });
-        setTimeout(function () {
+        var $modal = $("#lead-form").closest(".modal");
+        $modal.on("shown.bs.modal", function () {
             $("#company_name").focus();
-        }, 200);
+        });
+        if ($modal.hasClass("show")) {
+            $("#company_name").focus();
+        }
     });
     </script>
 


### PR DESCRIPTION
## Summary
- remove autofocus from company name fields in lead and client forms
- trigger company name focus after modal `shown.bs.modal` event

## Testing
- `php -l app/Views/leads/lead_form_fields.php`
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Views/leads/modal_form.php`
- `php -l app/Views/clients/modal_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68acab34d83c83328c2c16ad3352ffef