### PR TITLE
Harden address autocomplete observer initialization

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -112,8 +112,14 @@
     }
 
     function startObserver() {
-        var target = document.body || document.documentElement;
-        if (!target || typeof target.nodeType !== "number") {
+        var target = document.body;
+        if (!(target instanceof Node)) {
+            target = document.documentElement;
+        }
+        if (!(target instanceof Node)) {
+            target = document;
+        }
+        if (!(target instanceof Node)) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure Google address autocomplete attaches MutationObserver to a valid DOM Node
- fall back to `document.documentElement` or `document` to avoid type errors on internal views

## Testing
- `node --check assets/js/google_address_autocomplete.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acb107b8f883328c52ca2ba09e24d4