### PR TITLE
Add loading=async parameter for Google Maps API scripts

### DIFF
--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -316,7 +316,7 @@ table.dataTable tbody td:first-child {
 <?php $googleMapsApiKey = get_setting('google_maps_api_key'); ?>
 <?php if ($googleMapsApiKey) { ?>
 <!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete&loading=async" async defer></script>
 <?php } ?>
 
 <script type="text/javascript">

--- a/app/Views/includes/custom_head.php
+++ b/app/Views/includes/custom_head.php
@@ -7,7 +7,7 @@ if (!$googleMapsApiKey) {
 
 if ($googleMapsApiKey) {
     ?>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $googleMapsApiKey ?>&libraries=places&callback=googleMapsReady"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $googleMapsApiKey ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
     <script>
         function googleMapsReady() {
             if (window.initAddressAutocomplete) {

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -353,7 +353,7 @@ table.dataTable tbody td:first-child {
 <?php $googleMapsApiKey = get_setting('google_maps_api_key'); ?>
 <?php if ($googleMapsApiKey) { ?>
 <!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete&loading=async" async defer></script>
 <?php } ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Summary
- Append `&loading=async` to Google Maps API script URLs
- Keep `async defer` attributes on all Google Maps API tags

## Testing
- `php -l app/Views/includes/custom_head.php`
- `php -l app/Views/collect_leads/index.php`
- `php -l app/Views/request_estimate/estimate_request_form.php`
- `npm install puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acb9ad47e08332aa8880e128577ab0