### PR TITLE
Replace Google Places Autocomplete with PlaceAutocompleteElement

### DIFF
--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -413,17 +413,18 @@ table.dataTable tbody td:first-child {
     // Google Places Autocomplete Initialization
     function initAutocomplete() {
         var addressInput = document.getElementById('address');
-        var autocomplete = new google.maps.places.Autocomplete(addressInput, {
-            types: ['address'],
-            componentRestrictions: { country: ['ca'] },
-            fields: ['address_components', 'geometry', 'formatted_address']
-        });
+        var autocomplete = new google.maps.places.PlaceAutocompleteElement();
+        autocomplete.id = addressInput.id;
+        autocomplete.name = addressInput.name;
+        autocomplete.className = addressInput.className;
+        autocomplete.setAttribute('placeholder', addressInput.placeholder || '');
+        addressInput.parentNode.replaceChild(autocomplete, addressInput);
 
-        autocomplete.addListener('place_changed', function() {
-            var place = autocomplete.getPlace();
+        autocomplete.addEventListener('place_changed', function() {
+            var place = autocomplete.place;
             var addressComponents = place.address_components;
 
-            $('#address').val('');
+            autocomplete.value = '';
             $('#city').val('');
             $('#state').val('');
             $('#zip').val('');
@@ -461,7 +462,7 @@ table.dataTable tbody td:first-child {
             }
 
             var fullAddress = streetNumber && route ? streetNumber + ' ' + route : route;
-            $('#address').val(fullAddress);
+            autocomplete.value = fullAddress;
             $('#city').val(city);
             $('#state').val(province).trigger('change');
             $('#zip').val(postalCode);

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -403,17 +403,18 @@ table.dataTable tbody td:first-child {
     // Google Places Autocomplete Initialization
     function initAutocomplete() {
         var addressInput = document.getElementById('address');
-        var autocomplete = new google.maps.places.Autocomplete(addressInput, {
-            types: ['address'],
-            componentRestrictions: { country: ['ca'] },
-            fields: ['address_components', 'geometry', 'formatted_address']
-        });
+        var autocomplete = new google.maps.places.PlaceAutocompleteElement();
+        autocomplete.id = addressInput.id;
+        autocomplete.name = addressInput.name;
+        autocomplete.className = addressInput.className;
+        autocomplete.setAttribute('placeholder', addressInput.placeholder || '');
+        addressInput.parentNode.replaceChild(autocomplete, addressInput);
 
-        autocomplete.addListener('place_changed', function() {
-            var place = autocomplete.getPlace();
+        autocomplete.addEventListener('place_changed', function() {
+            var place = autocomplete.place;
             var addressComponents = place.address_components;
 
-            $('#address').val('');
+            autocomplete.value = '';
             $('#city').val('');
             $('#state').val('');
             $('#zip').val('');
@@ -451,7 +452,7 @@ table.dataTable tbody td:first-child {
             }
 
             var fullAddress = streetNumber && route ? streetNumber + ' ' + route : route;
-            $('#address').val(fullAddress);
+            autocomplete.value = fullAddress;
             $('#city').val(city);
             $('#state').val(province);
             $('#zip').val(postalCode);

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -44,7 +44,12 @@
                 }
                 $address.data('gplaces-init', true);
 
-                var autocomplete = new google.maps.places.Autocomplete($address[0], { types: ['address'] });
+                var autocomplete = new google.maps.places.PlaceAutocompleteElement();
+                autocomplete.id = $address.attr('id');
+                autocomplete.name = $address.attr('name');
+                autocomplete.className = $address.attr('class');
+                autocomplete.setAttribute('placeholder', $address.attr('placeholder') || '');
+                $address.replaceWith(autocomplete);
 
                 var fields = ['address', 'city', 'state', 'zip', 'country'];
                 fields.forEach(function (field) {
@@ -53,9 +58,9 @@
                     $form.find('#' + field).attr('autocomplete', 'new-password');
                 });
 
-                autocomplete.addListener('place_changed', function () {
-                    var place = autocomplete.getPlace();
-                    if (!place.address_components) {
+                autocomplete.addEventListener('place_changed', function () {
+                    var place = autocomplete.place;
+                    if (!place || !place.address_components) {
                         return;
                     }
 
@@ -88,7 +93,7 @@
                     });
 
                     if (address) {
-                        $form.find('#address').val(address);
+                        autocomplete.value = address;
                     }
                     if (city) {
                         $form.find('#city').val(city);


### PR DESCRIPTION
## Summary
- migrate address scripts and forms from `google.maps.places.Autocomplete` to `google.maps.places.PlaceAutocompleteElement`
- update event handling to read selected data from the element's `place`/`value` properties

## Testing
- `node --check assets/js/google_address_autocomplete.js`
- `php -l app/Views/collect_leads/index.php`
- `php -l app/Views/request_estimate/estimate_request_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbb3631e08332b8c2015715c38c3b