### PR TITLE
Initialize Google Places after page load

### DIFF
--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -315,8 +315,15 @@ table.dataTable tbody td:first-child {
 
 <?php $googleMapsApiKey = get_setting('google_maps_api_key'); ?>
 <?php if ($googleMapsApiKey) { ?>
-<!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete&loading=async" async defer></script>
+    <script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+    <script>
+        function googleMapsReady() {
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(document);
+            }
+        }
+    </script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
 <?php } ?>
 
 <script type="text/javascript">

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -352,8 +352,15 @@ table.dataTable tbody td:first-child {
 </div>
 <?php $googleMapsApiKey = get_setting('google_maps_api_key'); ?>
 <?php if ($googleMapsApiKey) { ?>
-<!-- Google Maps API Script -->
-<script src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=initAutocomplete&loading=async" async defer></script>
+    <script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+    <script>
+        function googleMapsReady() {
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(document);
+            }
+        }
+    </script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
 <?php } ?>
 
 <script type="text/javascript">

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -119,3 +119,10 @@ $(document).on('shown.bs.modal', '#lead-modal, #client-modal', function () {
     initAddressAutocomplete(this);
 });
 
+// Ensure existing address fields are enhanced once the page is fully loaded
+window.addEventListener('load', function () {
+    if (window.initAddressAutocomplete) {
+        window.initAddressAutocomplete(document);
+    }
+});
+


### PR DESCRIPTION
## Summary
- Initialize address autocomplete after page load to avoid race conditions
- Load Google Places API after custom autocomplete script in public forms

## Testing
- `php -l app/Views/request_estimate/estimate_request_form.php`
- `php -l app/Views/collect_leads/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68acbc5163ac83329c9ade2d66ca8b95