### PR TITLE
Fix Google address autocomplete input handling

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -44,12 +44,10 @@
                 }
                 $address.data('gplaces-init', true);
 
-                var autocomplete = new google.maps.places.PlaceAutocompleteElement();
-                autocomplete.id = $address.attr('id');
-                autocomplete.name = $address.attr('name');
-                autocomplete.className = $address.attr('class');
-                autocomplete.setAttribute('placeholder', $address.attr('placeholder') || '');
-                $address.replaceWith(autocomplete);
+                var autocomplete = new google.maps.places.PlaceAutocompleteElement({
+                    inputElement: $address[0]
+                });
+                $(autocomplete).insertAfter($address);
 
                 var fields = ['address', 'city', 'state', 'zip', 'country'];
                 fields.forEach(function (field) {


### PR DESCRIPTION
## Summary
- Instantiate PlaceAutocompleteElement with existing input element
- Keep original address input in DOM and insert autocomplete host after it

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbf5101448332a9ae5295a5904078