### PR TITLE
Switch to gmp-placeselect event

### DIFF
--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -427,8 +427,11 @@ table.dataTable tbody td:first-child {
         autocomplete.setAttribute('placeholder', addressInput.placeholder || '');
         addressInput.parentNode.replaceChild(autocomplete, addressInput);
 
-        autocomplete.addEventListener('place_changed', function() {
-            var place = autocomplete.place;
+        autocomplete.addEventListener('gmp-placeselect', function(event) {
+            var place = (event.detail && event.detail.place) ? event.detail.place : event.target.value;
+            if (!place || !place.address_components) {
+                return;
+            }
             var addressComponents = place.address_components;
 
             autocomplete.value = '';
@@ -479,6 +482,7 @@ table.dataTable tbody td:first-child {
         });
     }
 </script>
+
 
 <!-- Listen for messages from the parent -->
 <script>

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -417,8 +417,11 @@ table.dataTable tbody td:first-child {
         autocomplete.setAttribute('placeholder', addressInput.placeholder || '');
         addressInput.parentNode.replaceChild(autocomplete, addressInput);
 
-        autocomplete.addEventListener('place_changed', function() {
-            var place = autocomplete.place;
+        autocomplete.addEventListener('gmp-placeselect', function(event) {
+            var place = (event.detail && event.detail.place) ? event.detail.place : event.target.value;
+            if (!place || !place.address_components) {
+                return;
+            }
             var addressComponents = place.address_components;
 
             autocomplete.value = '';

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -56,8 +56,8 @@
                     $form.find('#' + field).attr('autocomplete', 'new-password');
                 });
 
-                autocomplete.addEventListener('place_changed', function () {
-                    var place = autocomplete.place;
+                autocomplete.addEventListener('gmp-placeselect', function (event) {
+                    var place = (event.detail && event.detail.place) ? event.detail.place : event.target.value;
                     if (!place || !place.address_components) {
                         return;
                     }


### PR DESCRIPTION
## Summary
- Update Google Places autocomplete listeners to `gmp-placeselect`
- Access selected place via `event.detail.place` and populate address fields

## Testing
- `php -l app/Views/collect_leads/index.php`
- `php -l app/Views/request_estimate/estimate_request_form.php`
- `node --check assets/js/google_address_autocomplete.js && echo 'node check ok'`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acc044e84083329039fee97e049140