### PR TITLE
Fix Google Places integration for address fields

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -101,15 +101,13 @@
                     }
                 };
 
-                if (google.maps.places.PlaceAutocompleteElement) {
-                    var pa = new google.maps.places.PlaceAutocompleteElement();
-                    pa.fields = ['address_components'];
-                    pa.inputElement = $address[0];
-                    $address.after(pa);
-                    pa.addEventListener('gmp-placechange', function () {
-                        handlePlace(pa.getPlace());
-                    });
-                } else if (google.maps.places.Autocomplete) {
+                // Attach Google Places Autocomplete directly to the existing
+                // input field. Using the classic Autocomplete widget avoids
+                // replacing the form control with the experimental
+                // PlaceAutocompleteElement, which previously caused issues
+                // within our modals and prevented the selected address from
+                // populating the actual form fields.
+                if (google.maps.places.Autocomplete) {
                     var autocomplete = new google.maps.places.Autocomplete($address[0], {
                         fields: ['address_components']
                     });


### PR DESCRIPTION
## Summary
- Ensure Google Places Autocomplete attaches directly to existing address inputs
- Avoid experimental PlaceAutocompleteElement that prevented populating lead/client forms

## Testing
- `node --check assets/js/google_address_autocomplete.js`


------
https://chatgpt.com/codex/tasks/task_e_68adc8ff5fe08332aad2bd94e556fae9