### PR TITLE
refactor: migrate to PlaceAutocompleteElement

### DIFF
--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -101,13 +101,16 @@
                     }
                 };
 
-                // Attach Google Places Autocomplete directly to the existing
-                // input field. Using the classic Autocomplete widget avoids
-                // replacing the form control with the experimental
-                // PlaceAutocompleteElement, which previously caused issues
-                // within our modals and prevented the selected address from
-                // populating the actual form fields.
-                if (google.maps.places.Autocomplete) {
+                // Prefer the newer PlaceAutocompleteElement when available to
+                // avoid reliance on the deprecated Autocomplete widget.
+                if (google.maps.places.PlaceAutocompleteElement) {
+                    var autocomplete = new google.maps.places.PlaceAutocompleteElement();
+                    autocomplete.fields = ['addressComponents'];
+                    autocomplete.inputElement = $address[0];
+                    autocomplete.addEventListener('gmpx-placechange', function () {
+                        handlePlace(autocomplete.getPlace());
+                    });
+                } else if (google.maps.places.Autocomplete) {
                     var autocomplete = new google.maps.places.Autocomplete($address[0], {
                         fields: ['address_components']
                     });


### PR DESCRIPTION
## Summary
- replace deprecated `google.maps.places.Autocomplete` with `PlaceAutocompleteElement`
- fall back to old Autocomplete if the new element isn't available

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adca57af04833287067e84d4f03299