### PR TITLE
Initialize Google Places only inside lead/client modals

### DIFF
--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -76,9 +76,65 @@
             window.showAddNewModal = true;
             $(this).trigger("submit");
         });
-        if (window.initAddressAutocomplete) {
-            window.initAddressAutocomplete('#client-form');
+
+        // Initialize Google Places Autocomplete on this form only.
+        function initFormAddressAutocomplete(formSelector) {
+            var form = document.querySelector(formSelector);
+            if (!form || typeof google === 'undefined' || !google.maps || !google.maps.places) {
+                return;
+            }
+
+            var addressInput = form.querySelector('#address');
+            if (!addressInput) {
+                return;
+            }
+
+            ['address', 'city', 'state', 'zip', 'country'].forEach(function (id) {
+                var field = form.querySelector('#' + id);
+                if (field) {
+                    field.setAttribute('autocomplete', 'new-password');
+                }
+            });
+
+            var autocomplete = new google.maps.places.Autocomplete(addressInput, {fields: ['address_components']});
+            autocomplete.addListener('place_changed', function () {
+                var place = autocomplete.getPlace();
+                if (!place.address_components) {
+                    return;
+                }
+
+                var address = '', city = '', state = '', zip = '', country = '';
+                place.address_components.forEach(function (component) {
+                    var types = component.types;
+                    if (types.indexOf('street_number') > -1) {
+                        address = component.long_name + (address ? ' ' + address : '');
+                    }
+                    if (types.indexOf('route') > -1) {
+                        address = address ? address + ' ' + component.long_name : component.long_name;
+                    }
+                    if (types.indexOf('locality') > -1) {
+                        city = component.long_name;
+                    }
+                    if (types.indexOf('administrative_area_level_1') > -1) {
+                        state = component.short_name;
+                    }
+                    if (types.indexOf('postal_code') > -1) {
+                        zip = component.long_name;
+                    }
+                    if (types.indexOf('country') > -1) {
+                        country = component.long_name;
+                    }
+                });
+
+                if (address) { form.querySelector('#address').value = address; }
+                if (city) { form.querySelector('#city').value = city; }
+                if (state) { form.querySelector('#state').value = state; }
+                if (zip) { form.querySelector('#zip').value = zip; }
+                if (country) { form.querySelector('#country').value = country; }
+            });
         }
+
+        initFormAddressAutocomplete('#client-form');
     });
 </script>
 

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -33,9 +33,65 @@
         if ($modal.hasClass("show")) {
             $("#company_name").focus();
         }
-        if (window.initAddressAutocomplete) {
-            window.initAddressAutocomplete('#lead-form');
+
+        // Initialize Google Places Autocomplete on this form only.
+        function initFormAddressAutocomplete(formSelector) {
+            var form = document.querySelector(formSelector);
+            if (!form || typeof google === 'undefined' || !google.maps || !google.maps.places) {
+                return;
+            }
+
+            var addressInput = form.querySelector('#address');
+            if (!addressInput) {
+                return;
+            }
+
+            ['address', 'city', 'state', 'zip', 'country'].forEach(function (id) {
+                var field = form.querySelector('#' + id);
+                if (field) {
+                    field.setAttribute('autocomplete', 'new-password');
+                }
+            });
+
+            var autocomplete = new google.maps.places.Autocomplete(addressInput, {fields: ['address_components']});
+            autocomplete.addListener('place_changed', function () {
+                var place = autocomplete.getPlace();
+                if (!place.address_components) {
+                    return;
+                }
+
+                var address = '', city = '', state = '', zip = '', country = '';
+                place.address_components.forEach(function (component) {
+                    var types = component.types;
+                    if (types.indexOf('street_number') > -1) {
+                        address = component.long_name + (address ? ' ' + address : '');
+                    }
+                    if (types.indexOf('route') > -1) {
+                        address = address ? address + ' ' + component.long_name : component.long_name;
+                    }
+                    if (types.indexOf('locality') > -1) {
+                        city = component.long_name;
+                    }
+                    if (types.indexOf('administrative_area_level_1') > -1) {
+                        state = component.short_name;
+                    }
+                    if (types.indexOf('postal_code') > -1) {
+                        zip = component.long_name;
+                    }
+                    if (types.indexOf('country') > -1) {
+                        country = component.long_name;
+                    }
+                });
+
+                if (address) { form.querySelector('#address').value = address; }
+                if (city) { form.querySelector('#city').value = city; }
+                if (state) { form.querySelector('#state').value = state; }
+                if (zip) { form.querySelector('#zip').value = zip; }
+                if (country) { form.querySelector('#country').value = country; }
+            });
         }
+
+        initFormAddressAutocomplete('#lead-form');
     });
     </script>
 

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -125,16 +125,5 @@
     };
 })(window);
 
-// Initialize autocomplete when users interact with the page
-$(document).on('focus', '#lead-form #address, #client-form #address', initAddressAutocomplete);
-$(document).on('shown.bs.modal', '#lead-modal, #client-modal', function () {
-    initAddressAutocomplete(this);
-});
-
-// Ensure existing address fields are enhanced once the page is fully loaded
-window.addEventListener('load', function () {
-    if (window.initAddressAutocomplete) {
-        window.initAddressAutocomplete(document);
-    }
-});
+// Forms should call window.initAddressAutocomplete(form) after rendering
 


### PR DESCRIPTION
## Summary
- Inline Google Places Autocomplete initialization in add-client and add-lead modals
- Remove global auto-bindings from `google_address_autocomplete.js`

## Testing
- `php -l app/Views/clients/modal_form.php`
- `php -l app/Views/leads/modal_form.php`
- `node --check assets/js/google_address_autocomplete.js`


------
https://chatgpt.com/codex/tasks/task_e_68adcb7615f883328d962acd88ffcab8