### PR TITLE
Simplify client and lead forms for Google Places support

### DIFF
--- a/app/Views/clients/client_form_fields.php
+++ b/app/Views/clients/client_form_fields.php
@@ -79,15 +79,21 @@
             </label>
             <div class="<?php echo $field_column; ?>">
                 <?php
-                echo form_input(array(
-                    "id" => "owner_id", // Changed from created_by
-                    "name" => "owner_id", // Changed from created_by
-                    "value" => $model_info->owner_id ? $model_info->owner_id : $login_user->id, // Use owner_id from model
-                    "class" => "form-control",
-                    "placeholder" => app_lang('owner'),
-                    "data-rule-required" => true,
-                    "data-msg-required" => app_lang("field_required")
-                ));
+                $owner_options = [];
+                if (!empty($team_members_dropdown)) {
+                    $members = json_decode($team_members_dropdown, true);
+                    if (is_array($members)) {
+                        foreach ($members as $member) {
+                            $owner_options[$member['id']] = $member['text'];
+                        }
+                    }
+                }
+                echo form_dropdown(
+                    "owner_id",
+                    $owner_options,
+                    $model_info->owner_id ? $model_info->owner_id : $login_user->id,
+                    "class='form-control' id='owner_id' data-rule-required='true' data-msg-required='" . app_lang("field_required") . "'"
+                );
                 ?>
             </div>
         </div>
@@ -104,7 +110,7 @@
                 $lead_status_dropdown[$status->id] = $status->title;
             }
             $selected_status = $model_info->lead_status_id ? $model_info->lead_status_id : 1;
-            echo form_dropdown("lead_status_id", $lead_status_dropdown, array($selected_status), "class='select2' id='client_lead_status_id'");
+            echo form_dropdown("lead_status_id", $lead_status_dropdown, $selected_status, "class='form-control' id='client_lead_status_id'");
             ?>
         </div>
     </div>
@@ -359,36 +365,6 @@
     $(document).ready(function() {
         $('[data-bs-toggle="tooltip"]').tooltip();
 
-        <?php if (isset($currency_dropdown)) { ?>
-            if ($('#currency').length) {
-                $('#currency').select2({
-                    data: <?php echo json_encode($currency_dropdown); ?>
-                });
-            }
-        <?php } ?>
-
-        <?php if (isset($groups_dropdown)) { ?>
-            $("#group_ids").select2({
-                multiple: true,
-                data: <?php echo json_encode($groups_dropdown); ?>
-            });
-        <?php } ?>
-
-
-        <?php if ($login_user->is_admin || get_array_value($login_user->permissions, "client") === "all") { ?>
-            $('#owner_id').select2({ // Changed from created_by
-                data: <?php echo $team_members_dropdown; ?>
-            });
-        <?php } ?>
-
-        $('#client_lead_status_id').select2();
-
-        <?php if ($login_user->user_type === "staff" && empty($hide_client_labels)) { ?>
-            $("#client_labels").select2({
-                multiple: true,
-                data: <?php echo json_encode($label_suggestions); ?>
-            });
-        <?php } ?>
         $('.account_type').click(function() {
             var inputValue = $(this).attr("value");
             if (inputValue === "person") {

--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -77,7 +77,7 @@
                 $lead_status[$status->id] = $status->title;
             }
 
-            echo form_dropdown("lead_status_id", $lead_status, array($model_info->lead_status_id), "class='select2'");
+            echo form_dropdown("lead_status_id", $lead_status, $model_info->lead_status_id, "class='form-control'");
             ?>
         </div>
     </div>
@@ -97,7 +97,7 @@
                     "owner_id",
                     $owners_select,
                     $model_info->owner_id ? $model_info->owner_id : $login_user->id,
-                    "class='form-control select2' id='owner_id'"
+                    "class='form-control' id='owner_id'"
             );
             ?>
         </div>
@@ -314,22 +314,6 @@
 <script type="text/javascript">
     $(document).ready(function() {
         $('[data-bs-toggle="tooltip"]').tooltip();
-        $(".select2").select2();
-
-        <?php if (isset($currency_dropdown)) { ?>
-            if ($('#currency').length) {
-                $('#currency').select2({
-                    data: <?php echo json_encode($currency_dropdown); ?>
-                });
-            }
-        <?php } ?>
-
-        $('#owner_id').select2();
-
-        $("#lead_labels").select2({
-            multiple: true,
-            data: <?php echo json_encode($label_suggestions); ?>
-        });
 
         $('.account_type').click(function() {
             var inputValue = $(this).attr("value");

--- a/app/Views/partials/lead_source_select.php
+++ b/app/Views/partials/lead_source_select.php
@@ -12,13 +12,8 @@ if (isset($sources_dropdown)) {
     }
 }
 ?>
-<select id="<?php echo $id; ?>" name="lead_source_id" class="form-control select2">
+<select id="<?php echo $id; ?>" name="lead_source_id" class="form-control">
     <?php foreach ($dropdown_data as $item) { ?>
         <option value="<?php echo $item['id']; ?>" <?php echo ($selected == $item['id']) ? 'selected' : ''; ?>><?php echo $item['text']; ?></option>
     <?php } ?>
 </select>
-<script>
-    $(function () {
-        $('#<?php echo $id; ?>').select2();
-    });
-</script>


### PR DESCRIPTION
## Summary
- Replace select2-driven dropdowns in client and lead forms with standard inputs for compatibility with Google Places autocomplete
- Strip select2 initialization scripts from client and lead views
- Remove select2 setup from shared lead source select partial

## Testing
- `php -l app/Views/clients/client_form_fields.php`
- `php -l app/Views/leads/lead_form_fields.php`
- `php -l app/Views/partials/lead_source_select.php`


------
https://chatgpt.com/codex/tasks/task_e_68add57b5bf48332a98e04ec18fa313a