### PR TITLE
Use PlaceAutocompleteElement for address forms

### DIFF
--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -77,64 +77,10 @@
             $(this).trigger("submit");
         });
 
-        // Initialize Google Places Autocomplete on this form only.
-        function initFormAddressAutocomplete(formSelector) {
-            var form = document.querySelector(formSelector);
-            if (!form || typeof google === 'undefined' || !google.maps || !google.maps.places) {
-                return;
-            }
-
-            var addressInput = form.querySelector('#address');
-            if (!addressInput) {
-                return;
-            }
-
-            ['address', 'city', 'state', 'zip', 'country'].forEach(function (id) {
-                var field = form.querySelector('#' + id);
-                if (field) {
-                    field.setAttribute('autocomplete', 'new-password');
-                }
-            });
-
-            var autocomplete = new google.maps.places.Autocomplete(addressInput, {fields: ['address_components']});
-            autocomplete.addListener('place_changed', function () {
-                var place = autocomplete.getPlace();
-                if (!place.address_components) {
-                    return;
-                }
-
-                var address = '', city = '', state = '', zip = '', country = '';
-                place.address_components.forEach(function (component) {
-                    var types = component.types;
-                    if (types.indexOf('street_number') > -1) {
-                        address = component.long_name + (address ? ' ' + address : '');
-                    }
-                    if (types.indexOf('route') > -1) {
-                        address = address ? address + ' ' + component.long_name : component.long_name;
-                    }
-                    if (types.indexOf('locality') > -1) {
-                        city = component.long_name;
-                    }
-                    if (types.indexOf('administrative_area_level_1') > -1) {
-                        state = component.short_name;
-                    }
-                    if (types.indexOf('postal_code') > -1) {
-                        zip = component.long_name;
-                    }
-                    if (types.indexOf('country') > -1) {
-                        country = component.long_name;
-                    }
-                });
-
-                if (address) { form.querySelector('#address').value = address; }
-                if (city) { form.querySelector('#city').value = city; }
-                if (state) { form.querySelector('#state').value = state; }
-                if (zip) { form.querySelector('#zip').value = zip; }
-                if (country) { form.querySelector('#country').value = country; }
-            });
+        // Initialize address autocomplete using shared helper.
+        if (window.initAddressAutocomplete) {
+            window.initAddressAutocomplete('#client-form');
         }
-
-        initFormAddressAutocomplete('#client-form');
     });
 </script>
 

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -323,7 +323,7 @@ table.dataTable tbody td:first-child {
             }
         }
     </script>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&v=beta&callback=googleMapsReady&loading=async"></script>
 <?php } ?>
 
 <script type="text/javascript">

--- a/app/Views/includes/custom_head.php
+++ b/app/Views/includes/custom_head.php
@@ -7,7 +7,7 @@ if (!$googleMapsApiKey) {
 
 if ($googleMapsApiKey) {
     ?>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $googleMapsApiKey ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $googleMapsApiKey ?>&libraries=places&v=beta&callback=googleMapsReady&loading=async"></script>
     <script>
         function googleMapsReady() {
             if (window.initAddressAutocomplete) {

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -34,64 +34,10 @@
             $("#company_name").focus();
         }
 
-        // Initialize Google Places Autocomplete on this form only.
-        function initFormAddressAutocomplete(formSelector) {
-            var form = document.querySelector(formSelector);
-            if (!form || typeof google === 'undefined' || !google.maps || !google.maps.places) {
-                return;
-            }
-
-            var addressInput = form.querySelector('#address');
-            if (!addressInput) {
-                return;
-            }
-
-            ['address', 'city', 'state', 'zip', 'country'].forEach(function (id) {
-                var field = form.querySelector('#' + id);
-                if (field) {
-                    field.setAttribute('autocomplete', 'new-password');
-                }
-            });
-
-            var autocomplete = new google.maps.places.Autocomplete(addressInput, {fields: ['address_components']});
-            autocomplete.addListener('place_changed', function () {
-                var place = autocomplete.getPlace();
-                if (!place.address_components) {
-                    return;
-                }
-
-                var address = '', city = '', state = '', zip = '', country = '';
-                place.address_components.forEach(function (component) {
-                    var types = component.types;
-                    if (types.indexOf('street_number') > -1) {
-                        address = component.long_name + (address ? ' ' + address : '');
-                    }
-                    if (types.indexOf('route') > -1) {
-                        address = address ? address + ' ' + component.long_name : component.long_name;
-                    }
-                    if (types.indexOf('locality') > -1) {
-                        city = component.long_name;
-                    }
-                    if (types.indexOf('administrative_area_level_1') > -1) {
-                        state = component.short_name;
-                    }
-                    if (types.indexOf('postal_code') > -1) {
-                        zip = component.long_name;
-                    }
-                    if (types.indexOf('country') > -1) {
-                        country = component.long_name;
-                    }
-                });
-
-                if (address) { form.querySelector('#address').value = address; }
-                if (city) { form.querySelector('#city').value = city; }
-                if (state) { form.querySelector('#state').value = state; }
-                if (zip) { form.querySelector('#zip').value = zip; }
-                if (country) { form.querySelector('#country').value = country; }
-            });
+        // Initialize address autocomplete using shared helper.
+        if (window.initAddressAutocomplete) {
+            window.initAddressAutocomplete('#lead-form');
         }
-
-        initFormAddressAutocomplete('#lead-form');
     });
     </script>
 

--- a/app/Views/request_estimate/estimate_request_form.php
+++ b/app/Views/request_estimate/estimate_request_form.php
@@ -360,7 +360,7 @@ table.dataTable tbody td:first-child {
             }
         }
     </script>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&callback=googleMapsReady&loading=async"></script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&v=beta&callback=googleMapsReady&loading=async"></script>
 <?php } ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
## Summary
- Initialize client and lead forms with shared `initAddressAutocomplete` helper backed by PlaceAutocompleteElement
- Load Google Maps JS API with `v=beta` so the new Places widget is available

## Testing
- `php -l app/Views/clients/modal_form.php`
- `php -l app/Views/leads/modal_form.php`
- `php -l app/Views/includes/custom_head.php`
- `php -l app/Views/collect_leads/index.php`
- `php -l app/Views/request_estimate/estimate_request_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68add92261b08332b829efdf2f4d89e8