### PR TITLE
Initialize Places autocomplete on client/lead edit pages

### DIFF
--- a/app/Views/clients/contacts/company_info_tab.php
+++ b/app/Views/clients/contacts/company_info_tab.php
@@ -28,5 +28,9 @@
                 appAlert.success(result.message, {duration: 10000});
             }
         });
+
+        if (window.initAddressAutocomplete) {
+            window.initAddressAutocomplete('#company-form');
+        }
     });
 </script>

--- a/app/Views/leads/contacts/company_info_tab.php
+++ b/app/Views/leads/contacts/company_info_tab.php
@@ -26,5 +26,9 @@
                 appAlert.success(result.message, {duration: 10000});
             }
         });
+
+        if (window.initAddressAutocomplete) {
+            window.initAddressAutocomplete('#company-form');
+        }
     });
 </script>

--- a/assets/js/google_address_autocomplete.js
+++ b/assets/js/google_address_autocomplete.js
@@ -14,11 +14,11 @@
 
         var $forms = $();
         if ($root.length) {
-            if ($root.is('#lead-form, #client-form')) {
+            if ($root.is('#lead-form, #client-form, #company-form')) {
                 $forms = $root;
             } else {
-                $forms = $root.closest('#lead-form, #client-form')
-                    .add($root.find('#lead-form, #client-form'));
+                $forms = $root.closest('#lead-form, #client-form, #company-form')
+                    .add($root.find('#lead-form, #client-form, #company-form'));
             }
         }
 
@@ -132,7 +132,7 @@ $(function () {
 });
 
 // Initialize when an address field receives focus
-$(document).on('focus', '#lead-form #address, #client-form #address', function () {
+$(document).on('focus', '#lead-form #address, #client-form #address, #company-form #address', function () {
     window.initAddressAutocomplete(this);
 });
 


### PR DESCRIPTION
## Summary
- load address autocomplete for clients and leads when editing in regular views
- support `#company-form` in address autocomplete helper so non-modal forms are recognized

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l app/Views/clients/contacts/company_info_tab.php`
- `php -l app/Views/leads/contacts/company_info_tab.php`
- `node --check assets/js/google_address_autocomplete.js`


------
https://chatgpt.com/codex/tasks/task_e_68adde2705e08332b47bb86010f49800