### PR TITLE
Initialize address autocomplete in modal forms

### DIFF
--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -64,9 +64,15 @@
         var $modal = $("#client-form").closest(".modal");
         $modal.on("shown.bs.modal", function () {
             $("#company_name").focus();
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(this);
+            }
         });
         if ($modal.hasClass("show")) {
             $("#company_name").focus();
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete($modal[0]);
+            }
         }
 
         //save and open add new contact member modal
@@ -77,10 +83,6 @@
             $(this).trigger("submit");
         });
 
-        // Initialize address autocomplete using shared helper.
-        if (window.initAddressAutocomplete) {
-            window.initAddressAutocomplete('#client-form');
-        }
     });
 </script>
 

--- a/app/Views/company/modal_form.php
+++ b/app/Views/company/modal_form.php
@@ -188,5 +188,15 @@
         setTimeout(function() {
             $("#name").focus();
         }, 200);
+
+        var $modal = $("#company-form").closest(".modal");
+        $modal.on("shown.bs.modal", function () {
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(this);
+            }
+        });
+        if ($modal.hasClass("show") && window.initAddressAutocomplete) {
+            window.initAddressAutocomplete($modal[0]);
+        }
     });
 </script>

--- a/app/Views/includes/custom_head.php
+++ b/app/Views/includes/custom_head.php
@@ -19,8 +19,6 @@ if ($googleMapsApiKey) {
 }
 ?>
 
-<script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
-
 <script>
 window.addAppTableDisplayOption = 10000;
 </script>

--- a/app/Views/layout/index.php
+++ b/app/Views/layout/index.php
@@ -101,6 +101,8 @@ $dynamic_class .= " " . strtolower(get_actual_controller_name($router)) . "-page
         echo view("includes/summernote");
     } ?>
 
+    <script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+
     <nav class="mobile-bottom-menu navbar-expand-lg b-t bg-white fixed-bottom d-block d-sm-none">
         <div class="d-flex justify-content-between pl15 pr15">
             <a class="nav-link sidebar-toggle-btn" aria-current="page" href="#">

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -29,14 +29,15 @@
         var $modal = $("#lead-form").closest(".modal");
         $modal.on("shown.bs.modal", function () {
             $("#company_name").focus();
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(this);
+            }
         });
         if ($modal.hasClass("show")) {
             $("#company_name").focus();
-        }
-
-        // Initialize address autocomplete using shared helper.
-        if (window.initAddressAutocomplete) {
-            window.initAddressAutocomplete('#lead-form');
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete($modal[0]);
+            }
         }
     });
     </script>


### PR DESCRIPTION
## Summary
- Load google_address_autocomplete.js in global layout for modal access
- Initialize address autocomplete when client, lead, and company modals are shown, covering already visible modals

## Testing
- php -l app/Views/layout/index.php
- php -l app/Views/includes/custom_head.php
- php -l app/Views/clients/modal_form.php
- php -l app/Views/leads/modal_form.php
- php -l app/Views/company/modal_form.php

------
https://chatgpt.com/codex/tasks/task_e_68adf0799d1083328215b1c4caa4a363