### PR TITLE
Add leaderboard report for closed won opportunities

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -2477,6 +2477,66 @@ private function _save_a_row_of_excel_data($row_data) {
         );
     }
 
+    function leaderboard() {
+        $this->access_only_allowed_members();
+
+        $view_data["team_members_dropdown"] = $this->get_team_members_dropdown(true);
+
+        $roles_dropdown = array(
+            array("id" => "", "text" => "- " . app_lang("role") . " -"),
+            array("id" => "1", "text" => app_lang("commercial_sales")),
+            array("id" => "7", "text" => app_lang("residential"))
+        );
+        $view_data["roles_dropdown"] = json_encode($roles_dropdown);
+
+        $roc_dropdown = array(
+            array("id" => "", "text" => "- " . app_lang("roc") . " -"),
+            array("id" => "Ontario", "text" => "Ontario"),
+            array("id" => "Atlantic", "text" => "Atlantic"),
+            array("id" => "Quebec", "text" => "Quebec"),
+            array("id" => "Pacific", "text" => "Pacific"),
+            array("id" => "Prairies", "text" => "Prairies")
+        );
+        $view_data["roc_dropdown"] = json_encode($roc_dropdown);
+
+        return $this->template->rander("clients/reports/leaderboard", $view_data);
+    }
+
+    function leaderboard_data() {
+        $this->access_only_allowed_members();
+
+        $options = array(
+            "owner_id" => $this->request->getPost("owner_id"),
+            "roc" => $this->request->getPost("roc"),
+            "role_id" => $this->request->getPost("role_id"),
+            "start_date" => $this->request->getPost("start_date"),
+            "end_date" => $this->request->getPost("end_date")
+        );
+
+        $list_data = $this->Clients_model->get_leaderboard($options)->getResult();
+
+        $result = array();
+        foreach ($list_data as $data) {
+            $result[] = $this->_make_leaderboard_row($data);
+        }
+
+        echo json_encode(array("data" => $result));
+    }
+
+    private function _make_leaderboard_row($data) {
+        $member = get_team_member_profile_link($data->staff_id, $data->sales_rep_name);
+        $role = $data->role_id == 1 ? app_lang("commercial_sales") : app_lang("residential");
+
+        return array(
+            $member,
+            $role,
+            $data->roc,
+            $data->closed_won,
+            to_decimal_format($data->total_volume),
+            to_currency($data->total_margin)
+        );
+    }
+
     function load_client_dashboard_summary() {
         $this->access_only_allowed_members();
 

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -98,6 +98,7 @@ if (!function_exists('get_reports_topbar')) {
             $reports_menu[] = array("name" => "opportunities_graphs", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
             $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
             $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
+            $reports_menu[] = array("name" => "leaderboard", "url" => "clients/leaderboard", "class" => "award", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2799,4 +2799,13 @@ $lang['show_in_public_form'] = 'Show in public form';
 $lang['full_form'] = 'Full form';
 $lang['volume_by_opportunity_status'] = 'Volume by Opportunity Status';
 
+$lang["leaderboard"] = "Leaderboard";
+$lang["role"] = "Role";
+$lang["closed_won_opportunities"] = "# of Closed Won Opportunities";
+$lang["total_volume"] = "Total Volume";
+$lang["total_margin"] = "Total Margin";
+$lang["commercial_sales"] = "Commercial sales";
+$lang["residential"] = "Residential";
+$lang["closed_date"] = "Closed Date";
+
 return $lang;

--- a/app/Views/clients/reports/leaderboard.php
+++ b/app/Views/clients/reports/leaderboard.php
@@ -1,0 +1,36 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="table-responsive">
+            <table id="clients-leaderboard" class="display" width="100%"></table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#clients-leaderboard").appTable({
+            source: '<?php echo_uri("clients/leaderboard_data"); ?>',
+            filterDropdown: [
+                {name: "owner_id", class: "w200", options: <?php echo $team_members_dropdown; ?>},
+                {name: "role_id", class: "w200", options: <?php echo $roles_dropdown; ?>},
+                {name: "roc", class: "w200", options: <?php echo $roc_dropdown; ?>}
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('closed_date'); ?>", showClearButton: true}
+            ],
+            columns: [
+                {title: "<?php echo app_lang('sales_rep_name'); ?>", class: "all"},
+                {title: "<?php echo app_lang('role'); ?>"},
+                {title: "<?php echo app_lang('roc'); ?>"},
+                {title: "<?php echo app_lang('closed_won_opportunities'); ?>", class: "text-center"},
+                {title: "<?php echo app_lang('total_volume'); ?>", class: "text-right"},
+                {title: "<?php echo app_lang('total_margin'); ?>", class: "text-right"}
+            ],
+            order: [[3, "desc"]],
+            printColumns: [0, 1, 2, 3, 4, 5],
+            xlsColumns: [0, 1, 2, 3, 4, 5]
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add leaderboard report showing closed won opportunities with volume and margin totals
- enable filtering by sales rep, role, ROC and closed date
- register leaderboard in reports menu and localize new labels

## Testing
- `php -l app/Controllers/Clients.php`
- `php -l app/Models/Clients_model.php`
- `php -l app/Helpers/reports_helper.php`
- `php -l app/Language/english/custom_lang.php`
- `php -l app/Views/clients/reports/leaderboard.php`
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a2f16fc88332a84f5a8b08eb15a2