### PR TITLE
Add NPS survey tables and models for Polls plugin

### DIFF
--- a/plugins/Polls/Helpers/nps_helper.php
+++ b/plugins/Polls/Helpers/nps_helper.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Fetch NPS surveys
+ * @param array $options
+ * @return \CodeIgniter\Database\ResultInterface
+ */
+if (!function_exists('nps_get_surveys')) {
+    function nps_get_surveys($options = array()) {
+        $model = new \Polls\Models\Nps_surveys_model();
+        return $model->get_details($options);
+    }
+}
+
+/**
+ * Fetch NPS questions
+ * @param array $options
+ * @return \CodeIgniter\Database\ResultInterface
+ */
+if (!function_exists('nps_get_questions')) {
+    function nps_get_questions($options = array()) {
+        $model = new \Polls\Models\Nps_questions_model();
+        return $model->get_details($options);
+    }
+}
+
+/**
+ * Save NPS score
+ * @param array $data
+ * @return int|bool
+ */
+if (!function_exists('nps_save_score')) {
+    function nps_save_score($data = array()) {
+        $model = new \Polls\Models\Nps_responses_model();
+        return $model->save_score($data);
+    }
+}
+

--- a/plugins/Polls/Models/Nps_questions_model.php
+++ b/plugins/Polls/Models/Nps_questions_model.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Polls\Models;
+
+class Nps_questions_model extends \App\Models\Crud_model {
+
+    protected $table = null;
+
+    function __construct() {
+        $this->table = 'nps_questions';
+        parent::__construct($this->table);
+    }
+
+    function get_details($options = array()) {
+        $questions_table = $this->db->prefixTable('nps_questions');
+
+        $where = "";
+        $id = get_array_value($options, "id");
+        if ($id) {
+            $where .= " AND $questions_table.id=$id";
+        }
+
+        $survey_id = get_array_value($options, "survey_id");
+        if ($survey_id) {
+            $where .= " AND $questions_table.survey_id=$survey_id";
+        }
+
+        $sql = "SELECT $questions_table.*
+                FROM $questions_table
+                WHERE 1=1 $where
+                ORDER BY $questions_table.sort_order ASC";
+        return $this->db->query($sql);
+    }
+}
+

--- a/plugins/Polls/Models/Nps_responses_model.php
+++ b/plugins/Polls/Models/Nps_responses_model.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Polls\Models;
+
+class Nps_responses_model extends \App\Models\Crud_model {
+
+    protected $table = null;
+
+    function __construct() {
+        $this->table = 'nps_responses';
+        parent::__construct($this->table);
+    }
+
+    function get_details($options = array()) {
+        $responses_table = $this->db->prefixTable('nps_responses');
+
+        $where = "";
+        $survey_id = get_array_value($options, "survey_id");
+        if ($survey_id) {
+            $where .= " AND $responses_table.survey_id=$survey_id";
+        }
+
+        $token = get_array_value($options, "token");
+        if ($token) {
+            $where .= " AND $responses_table.token='$token'";
+        }
+
+        $sql = "SELECT $responses_table.*
+                FROM $responses_table
+                WHERE 1=1 $where";
+        return $this->db->query($sql);
+    }
+
+    function save_score($data) {
+        return $this->ci_save($data);
+    }
+}
+

--- a/plugins/Polls/Models/Nps_surveys_model.php
+++ b/plugins/Polls/Models/Nps_surveys_model.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Polls\Models;
+
+class Nps_surveys_model extends \App\Models\Crud_model {
+
+    protected $table = null;
+
+    function __construct() {
+        $this->table = 'nps_surveys';
+        parent::__construct($this->table);
+    }
+
+    function get_details($options = array()) {
+        $nps_surveys_table = $this->db->prefixTable('nps_surveys');
+
+        $where = "";
+        $id = get_array_value($options, "id");
+        if ($id) {
+            $where .= " AND $nps_surveys_table.id=$id";
+        }
+
+        $status = get_array_value($options, "status");
+        if ($status) {
+            $where .= " AND $nps_surveys_table.status='$status'";
+        }
+
+        $sql = "SELECT $nps_surveys_table.*
+                FROM $nps_surveys_table
+                WHERE 1=1 $where";
+        return $this->db->query($sql);
+    }
+}
+

--- a/plugins/Polls/install/database.sql
+++ b/plugins/Polls/install/database.sql
@@ -44,3 +44,30 @@ ALTER TABLE `notifications` ADD `plugin_poll_id` INT(11) NOT NULL AFTER `deleted
 
 INSERT INTO `email_templates`(`id`, `template_name`, `email_subject`, `default_message`, `custom_message`, `template_type`, `language`, `deleted`) VALUES 
 (NULL,'poll_created','New poll created','<div style="background-color: #eeeeef; padding: 50px 0; "> <div style="max-width:640px; margin:0 auto; "> <div style="color: #fff; text-align: center; background-color:#33333e; padding: 30px; border-top-left-radius: 3px; border-top-right-radius: 3px; margin: 0;"><h1>Poll #{POLL_ID}</h1></div><div style="padding: 20px; background-color: rgb(255, 255, 255);"><p style=""><span style="line-height: 18.5714px; font-weight: bold;">Title: {POLL_TITLE}</span><span style="line-height: 18.5714px;"><br></span></p><p style=""><span style="line-height: 18.5714px;">{POLL_DESCRIPTION}</span><br></p> <p style="">This poll will be expired {POLL_EXPIRE_AT}. Please check it out.</p><p style=""><br></p> <p style=""><span style="color: rgb(85, 85, 85); font-size: 14px; line-height: 20px;"><a style="background-color: #00b393; padding: 10px 15px; color: #ffffff;" href="{POLL_URL}" target="_blank">Show Poll</a></span></p> <p style=""><br></p>   </div>  </div> </div>',"","default","",0); --#
+CREATE TABLE IF NOT EXISTS `nps_surveys`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `title` TEXT COLLATE utf8_unicode_ci NOT NULL,
+    `description` TEXT COLLATE utf8_unicode_ci NULL,
+    `created_at` DATETIME NOT NULL,
+    `status` ENUM('active', 'inactive') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'active',
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci; --#
+
+CREATE TABLE IF NOT EXISTS `nps_questions`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `survey_id` INT(11) NOT NULL,
+    `question_text` TEXT COLLATE utf8_unicode_ci NOT NULL,
+    `sort_order` INT(11) NOT NULL DEFAULT '0',
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci; --#
+
+CREATE TABLE IF NOT EXISTS `nps_responses`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `survey_id` INT(11) NOT NULL,
+    `question_id` INT(11) NOT NULL,
+    `score` TINYINT(4) NOT NULL,
+    `token` VARCHAR(255) NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci; --#
+

--- a/plugins/Polls/updates/2024_06_15_add_nps_tables.sql
+++ b/plugins/Polls/updates/2024_06_15_add_nps_tables.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS `nps_surveys`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `title` TEXT COLLATE utf8_unicode_ci NOT NULL,
+    `description` TEXT COLLATE utf8_unicode_ci NULL,
+    `created_at` DATETIME NOT NULL,
+    `status` ENUM('active', 'inactive') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'active',
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `nps_questions`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `survey_id` INT(11) NOT NULL,
+    `question_text` TEXT COLLATE utf8_unicode_ci NOT NULL,
+    `sort_order` INT(11) NOT NULL DEFAULT '0',
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `nps_responses`(
+    `id` INT(11) NOT NULL AUTO_INCREMENT,
+    `survey_id` INT(11) NOT NULL,
+    `question_id` INT(11) NOT NULL,
+    `score` TINYINT(4) NOT NULL,
+    `token` VARCHAR(255) NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    PRIMARY KEY(`id`)
+) ENGINE = INNODB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci;


### PR DESCRIPTION
## Summary
- Add SQL definitions for NPS surveys, questions, and responses tables
- Provide migration script and models for NPS entities
- Expose helper functions for retrieving surveys/questions and saving scores

## Testing
- `php -l plugins/Polls/Models/Nps_surveys_model.php`
- `php -l plugins/Polls/Models/Nps_questions_model.php`
- `php -l plugins/Polls/Models/Nps_responses_model.php`
- `php -l plugins/Polls/Helpers/nps_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b73bebd6388332b65c1b24ccbedebc