### PR TITLE
Add NPS survey management

### DIFF
--- a/plugins/Polls/Config/Routes.php
+++ b/plugins/Polls/Config/Routes.php
@@ -10,6 +10,10 @@ $routes->get('polls', 'Polls::index', $polls_namespace);
 $routes->post('polls/(:any)', 'Polls::$1', $polls_namespace);
 $routes->get('polls/(:any)', 'Polls::$1', $polls_namespace);
 
+$routes->get('nps', 'Nps::index', $polls_namespace);
+$routes->post('nps/(:any)', 'Nps::$1', $polls_namespace);
+$routes->get('nps/(:any)', 'Nps::$1', $polls_namespace);
+
 $routes->get('poll_settings', 'Poll_settings::index', $polls_namespace);
 $routes->post('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);
 $routes->get('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);

--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Polls\Controllers;
+
+class Nps extends \App\Controllers\Security_Controller {
+
+    protected $Nps_surveys_model;
+    protected $Nps_questions_model;
+    protected $Nps_responses_model;
+
+    function __construct() {
+        parent::__construct();
+        $this->Nps_surveys_model = new \Polls\Models\Nps_surveys_model();
+        $this->Nps_questions_model = new \Polls\Models\Nps_questions_model();
+        $this->Nps_responses_model = new \Polls\Models\Nps_responses_model();
+    }
+
+    // list surveys
+    function index() {
+        $view_data["surveys"] = $this->Nps_surveys_model->get_details()->getResult();
+        return $this->template->rander("Polls\\Views\\nps\\index", $view_data);
+    }
+
+    // load survey add/edit modal
+    function modal_form() {
+        $id = $this->request->getPost('id');
+        $view_data['model_info'] = $this->Nps_surveys_model->get_one($id);
+        return $this->template->view('Polls\\Views\\nps\\modal_form', $view_data);
+    }
+
+    // save survey
+    function save() {
+        $this->validate_submitted_data(array(
+            "id" => "numeric",
+            "title" => "required"
+        ));
+
+        $id = $this->request->getPost('id');
+        $data = array(
+            "title" => $this->request->getPost('title'),
+            "description" => $this->request->getPost('description'),
+            "status" => $this->request->getPost('status') ? $this->request->getPost('status') : 'active'
+        );
+
+        if (!$id) {
+            $data['created_at'] = get_current_utc_time();
+        }
+
+        $save_id = $this->Nps_surveys_model->ci_save($data, $id);
+        if ($save_id) {
+            echo json_encode(array("success" => true, "id" => $save_id, "message" => app_lang('record_saved')));
+        } else {
+            echo json_encode(array("success" => false, "message" => app_lang('error_occurred')));
+        }
+    }
+
+    // load question add/edit modal
+    function question_form() {
+        $id = $this->request->getPost('id');
+        $survey_id = $this->request->getPost('survey_id');
+        $view_data['model_info'] = $this->Nps_questions_model->get_one($id);
+        $view_data['survey_id'] = $survey_id;
+        return $this->template->view('Polls\\Views\\nps\\question_form', $view_data);
+    }
+
+    // save question
+    function save_question() {
+        $this->validate_submitted_data(array(
+            "id" => "numeric",
+            "survey_id" => "required|numeric",
+            "title" => "required"
+        ));
+
+        $id = $this->request->getPost('id');
+        $data = array(
+            "survey_id" => $this->request->getPost('survey_id'),
+            "title" => $this->request->getPost('title'),
+            "sort_order" => $this->request->getPost('sort_order')
+        );
+
+        if (!$data['sort_order']) {
+            $existing = $this->Nps_questions_model->get_details(array("survey_id" => $data['survey_id']))->getResult();
+            $data['sort_order'] = count($existing) + 1;
+        }
+
+        $save_id = $this->Nps_questions_model->ci_save($data, $id);
+        if ($save_id) {
+            echo json_encode(array("success" => true, "id" => $save_id, "message" => app_lang('record_saved')));
+        } else {
+            echo json_encode(array("success" => false, "message" => app_lang('error_occurred')));
+        }
+    }
+
+    // show NPS report
+    function report($survey_id = 0) {
+        $survey = $this->Nps_surveys_model->get_one($survey_id);
+        if (!$survey || !$survey->id) {
+            show_404();
+        }
+
+        $responses = $this->Nps_responses_model->get_details(array("survey_id" => $survey_id))->getResult();
+        $promoters = $passives = $detractors = 0;
+        foreach ($responses as $response) {
+            $score = (int) $response->score;
+            if ($score >= 9) {
+                $promoters++;
+            } else if ($score >= 7) {
+                $passives++;
+            } else {
+                $detractors++;
+            }
+        }
+        $total = count($responses);
+        $nps_score = $total ? (($promoters - $detractors) / $total) * 100 : 0;
+
+        $view_data = array(
+            "survey" => $survey,
+            "promoters" => $promoters,
+            "passives" => $passives,
+            "detractors" => $detractors,
+            "nps_score" => $nps_score
+        );
+
+        return $this->template->rander("Polls\\Views\\nps\\report", $view_data);
+    }
+}
+
+/* End of file Nps.php */
+/* Location: ./plugins/Polls/Controllers/Nps.php */

--- a/plugins/Polls/Views/nps/index.php
+++ b/plugins/Polls/Views/nps/index.php
@@ -1,0 +1,28 @@
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="page-title clearfix">
+            <h1><?php echo app_lang('nps'); ?></h1>
+            <div class="title-button-group">
+                <?php echo modal_anchor(get_uri("nps/modal_form"), "<i data-feather='plus' class='icon-16'></i>" . app_lang('add'), array("class" => "btn btn-default", "title" => app_lang('add'))); ?>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="display dataTable" width="100%">
+                <thead>
+                    <tr>
+                        <th><?php echo app_lang("title"); ?></th>
+                        <th><?php echo app_lang("status"); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($surveys as $survey) { ?>
+                        <tr>
+                            <td><?php echo anchor(get_uri("nps/report/" . $survey->id), $survey->title); ?></td>
+                            <td><?php echo $survey->status; ?></td>
+                        </tr>
+                    <?php } ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/plugins/Polls/Views/nps/modal_form.php
+++ b/plugins/Polls/Views/nps/modal_form.php
@@ -1,0 +1,26 @@
+<?php echo form_open(get_uri("nps/save"), array("id" => "nps-form", "class" => "general-form", "role" => "form")); ?>
+<div class="modal-body clearfix">
+    <input type="hidden" name="id" value="<?php echo $model_info->id; ?>" />
+    <div class="form-group">
+        <label><?php echo app_lang("title"); ?></label>
+        <?php echo form_input(array("id" => "title", "name" => "title", "value" => $model_info->title, "class" => "form-control", "autofocus" => true, "required" => "required")); ?>
+    </div>
+    <div class="form-group">
+        <label><?php echo app_lang("description"); ?></label>
+        <?php echo form_textarea(array("id" => "description", "name" => "description", "value" => $model_info->description, "class" => "form-control")); ?>
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo app_lang("close"); ?></button>
+    <button type="submit" class="btn btn-primary"><?php echo app_lang("save"); ?></button>
+</div>
+<?php echo form_close(); ?>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#nps-form").appForm({
+            onSuccess: function (result) {
+                location.reload();
+            }
+        });
+    });
+</script>

--- a/plugins/Polls/Views/nps/question_form.php
+++ b/plugins/Polls/Views/nps/question_form.php
@@ -1,0 +1,23 @@
+<?php echo form_open(get_uri("nps/save_question"), array("id" => "nps-question-form", "class" => "general-form", "role" => "form")); ?>
+<div class="modal-body clearfix">
+    <input type="hidden" name="id" value="<?php echo $model_info->id; ?>" />
+    <input type="hidden" name="survey_id" value="<?php echo $survey_id; ?>" />
+    <div class="form-group">
+        <label><?php echo app_lang("question"); ?></label>
+        <?php echo form_input(array("id" => "title", "name" => "title", "value" => $model_info->title, "class" => "form-control", "required" => "required")); ?>
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" data-dismiss="modal"><?php echo app_lang("close"); ?></button>
+    <button type="submit" class="btn btn-primary"><?php echo app_lang("save"); ?></button>
+</div>
+<?php echo form_close(); ?>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#nps-question-form").appForm({
+            onSuccess: function (result) {
+                location.reload();
+            }
+        });
+    });
+</script>

--- a/plugins/Polls/Views/nps/report.php
+++ b/plugins/Polls/Views/nps/report.php
@@ -1,0 +1,15 @@
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="page-title clearfix">
+            <h1><?php echo $survey->title; ?></h1>
+        </div>
+        <div class="p15">
+            <p><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($nps_score, 2); ?></p>
+            <ul class="list-group">
+                <li class="list-group-item"><?php echo app_lang('promoters'); ?>: <?php echo $promoters; ?></li>
+                <li class="list-group-item"><?php echo app_lang('passives'); ?>: <?php echo $passives; ?></li>
+                <li class="list-group-item"><?php echo app_lang('detractors'); ?>: <?php echo $detractors; ?></li>
+            </ul>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add Nps controller to manage surveys, questions, and reports
- register NPS routes
- build NPS admin views for surveys and reports

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Views/nps/index.php`
- `php -l plugins/Polls/Views/nps/modal_form.php`
- `php -l plugins/Polls/Views/nps/question_form.php`
- `php -l plugins/Polls/Views/nps/report.php`


------
https://chatgpt.com/codex/tasks/task_e_68b73d3237b88332a2708f68229702fe