### PR TITLE
Add public NPS survey controller and routes

### DIFF
--- a/plugins/Polls/Config/Routes.php
+++ b/plugins/Polls/Config/Routes.php
@@ -14,6 +14,10 @@ $routes->get('nps', 'Nps::index', $polls_namespace);
 $routes->post('nps/(:any)', 'Nps::$1', $polls_namespace);
 $routes->get('nps/(:any)', 'Nps::$1', $polls_namespace);
 
+$routes->get('nps/s/(:num)', 'Nps_public::view/$1', $polls_namespace);
+$routes->post('nps/submit', 'Nps_public::submit', $polls_namespace);
+$routes->get('nps/embed/(:num)', 'Nps_public::embed/$1', $polls_namespace);
+
 $routes->get('poll_settings', 'Poll_settings::index', $polls_namespace);
 $routes->post('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);
 $routes->get('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);

--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Polls\Controllers;
+
+class Nps_public extends \App\Controllers\App_Controller {
+
+    protected $Nps_surveys_model;
+    protected $Nps_questions_model;
+    protected $Nps_responses_model;
+
+    public function __construct() {
+        parent::__construct();
+        $this->Nps_surveys_model = new \Polls\Models\Nps_surveys_model();
+        $this->Nps_questions_model = new \Polls\Models\Nps_questions_model();
+        $this->Nps_responses_model = new \Polls\Models\Nps_responses_model();
+    }
+
+    // render survey form
+    public function view($survey_id = 0) {
+        validate_numeric_value($survey_id);
+
+        $survey = $this->Nps_surveys_model->get_details(["id" => $survey_id, "status" => "active"])->getRow();
+        if (!$survey || !$survey->id) {
+            show_404();
+        }
+
+        $view_data = [
+            "survey" => $survey,
+            "questions" => $this->Nps_questions_model->get_details(["survey_id" => $survey_id])->getResult(),
+            "topbar" => "includes/public/topbar",
+            "left_menu" => false,
+            "embedded" => false
+        ];
+
+        return $this->template->rander("Polls\\Views\\nps\\public_survey", $view_data);
+    }
+
+    // store responses
+    public function submit() {
+        $this->validate_submitted_data([
+            "survey_id" => "required|numeric"
+        ]);
+
+        $survey_id = $this->request->getPost("survey_id");
+        $session = \Config\Services::session();
+        $token = $session->getId();
+        if (!$token) {
+            $token = bin2hex(random_bytes(16));
+        }
+
+        $existing = $this->Nps_responses_model->get_details(["survey_id" => $survey_id, "token" => $token])->getRow();
+        if ($existing) {
+            echo json_encode(["success" => false, "message" => app_lang("error_occurred")]);
+            return;
+        }
+
+        $scores = $this->request->getPost("score");
+        if ($scores && is_array($scores)) {
+            foreach ($scores as $question_id => $score) {
+                $data = [
+                    "survey_id" => $survey_id,
+                    "question_id" => $question_id,
+                    "score" => $score,
+                    "token" => $token,
+                    "created_at" => get_current_utc_time()
+                ];
+                $this->Nps_responses_model->save_score($data);
+            }
+        }
+
+        echo json_encode(["success" => true, "message" => app_lang("thank_you")]);
+    }
+
+    // lightweight view for iframe embedding
+    public function embed($survey_id = 0) {
+        validate_numeric_value($survey_id);
+
+        $survey = $this->Nps_surveys_model->get_details(["id" => $survey_id, "status" => "active"])->getRow();
+        if (!$survey || !$survey->id) {
+            show_404();
+        }
+
+        $view_data = [
+            "survey" => $survey,
+            "questions" => $this->Nps_questions_model->get_details(["survey_id" => $survey_id])->getResult(),
+            "embedded" => true
+        ];
+
+        return $this->template->view("Polls\\Views\\nps\\public_survey", $view_data);
+    }
+}
+
+/* End of file Nps_public.php */
+/* Location: ./plugins/Polls/Controllers/Nps_public.php */

--- a/plugins/Polls/Views/nps/public_survey.php
+++ b/plugins/Polls/Views/nps/public_survey.php
@@ -1,0 +1,66 @@
+<?php if ($embedded) { ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title><?php echo $survey->title; ?></title>
+    <style>
+        body {font-family: Arial, sans-serif; padding: 15px;}
+        .nps-scale label {margin-right: 6px;}
+        .nps-question {margin-bottom: 15px;}
+    </style>
+</head>
+<body>
+<?php } else { ?>
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="card-body">
+<?php } ?>
+
+<h3><?php echo $survey->title; ?></h3>
+<p><?php echo $survey->description; ?></p>
+
+<?php echo form_open(get_uri("nps/submit"), array("id" => "nps-form")); ?>
+<input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
+<?php foreach ($questions as $question) { ?>
+    <div class="nps-question">
+        <label><?php echo $question->title; ?></label>
+        <div class="nps-scale">
+            <?php for ($i = 0; $i <= 10; $i++) { ?>
+                <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>
+            <?php } ?>
+        </div>
+    </div>
+<?php } ?>
+<button type="submit" class="btn btn-primary"><?php echo app_lang('submit'); ?></button>
+<?php echo form_close(); ?>
+
+<?php if ($embedded) { ?>
+<script>
+var form = document.getElementById('nps-form');
+form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    fetch(form.action, {method: 'POST', body: new FormData(form)})
+        .then(function (response) { return response.json(); })
+        .then(function (data) {
+            form.innerHTML = data.message;
+        });
+});
+</script>
+</body>
+</html>
+<?php } else { ?>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#nps-form").appForm({
+            isModal: false,
+            onSuccess: function (result) {
+                $("#nps-form").html(result.message);
+            }
+        });
+    });
+</script>
+        </div>
+    </div>
+</div>
+<?php } ?>


### PR DESCRIPTION
## Summary
- Add `Nps_public` controller to render and submit NPS surveys with token-based duplicate protection.
- Create public survey view supporting full and embed modes.
- Register new public routes for NPS survey viewing, submission, and embedding.

## Testing
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Views/nps/public_survey.php`
- `php -l plugins/Polls/Config/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b73e0c098c8332a306f6971977662a