### PR TITLE
Add NPS embed view and auto-submit script

### DIFF
--- a/assets/js/nps_embed.js
+++ b/assets/js/nps_embed.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var form = document.getElementById('nps-form');
+    if (!form) {
+        return;
+    }
+
+    form.addEventListener('change', function (e) {
+        if (e.target && e.target.name && e.target.name.indexOf('score') === 0) {
+            fetch(form.action, {
+                method: 'POST',
+                body: new FormData(form)
+            }).then(function (response) {
+                return response.json();
+            }).then(function (data) {
+                form.innerHTML = data.message;
+            });
+        }
+    });
+});

--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -82,11 +82,10 @@ class Nps_public extends \App\Controllers\App_Controller {
 
         $view_data = [
             "survey" => $survey,
-            "questions" => $this->Nps_questions_model->get_details(["survey_id" => $survey_id])->getResult(),
-            "embedded" => true
+            "questions" => $this->Nps_questions_model->get_details(["survey_id" => $survey_id])->getResult()
         ];
 
-        return $this->template->view("Polls\\Views\\nps\\public_survey", $view_data);
+        return $this->template->view("Polls\\Views\\nps\\embed", $view_data);
     }
 }
 

--- a/plugins/Polls/Views/nps/embed.php
+++ b/plugins/Polls/Views/nps/embed.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title><?php echo $survey->title; ?></title>
+    <style>
+        body {font-family: Arial, sans-serif; padding: 15px;}
+        .nps-scale label {margin-right: 6px;}
+        .nps-question {margin-bottom: 15px;}
+    </style>
+</head>
+<body>
+    <?php echo view('Polls\\Views\\nps\\form', ['survey' => $survey, 'questions' => $questions, 'show_submit' => false]); ?>
+    <script src="<?php echo base_url('assets/js/nps_embed.js'); ?>"></script>
+</body>
+</html>

--- a/plugins/Polls/Views/nps/form.php
+++ b/plugins/Polls/Views/nps/form.php
@@ -1,0 +1,17 @@
+<?php echo form_open(get_uri("nps/submit"), array("id" => "nps-form")); ?>
+<input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
+<?php foreach ($questions as $question) { ?>
+    <div class="nps-question">
+        <label><?php echo $question->title; ?></label>
+        <input type="hidden" name="question_id[]" value="<?php echo $question->id; ?>" />
+        <div class="nps-scale">
+            <?php for ($i = 0; $i <= 10; $i++) { ?>
+                <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>
+            <?php } ?>
+        </div>
+    </div>
+<?php } ?>
+<?php if(isset($show_submit) && $show_submit){ ?>
+    <button type="submit" class="btn btn-primary"><?php echo app_lang('submit'); ?></button>
+<?php } ?>
+<?php echo form_close(); ?>

--- a/plugins/Polls/Views/nps/public_survey.php
+++ b/plugins/Polls/Views/nps/public_survey.php
@@ -1,55 +1,14 @@
-<?php if ($embedded) { ?>
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8" />
-    <title><?php echo $survey->title; ?></title>
-    <style>
-        body {font-family: Arial, sans-serif; padding: 15px;}
-        .nps-scale label {margin-right: 6px;}
-        .nps-question {margin-bottom: 15px;}
-    </style>
-</head>
-<body>
-<?php } else { ?>
 <div id="page-content" class="page-wrapper clearfix">
     <div class="card">
         <div class="card-body">
-<?php } ?>
+            <h3><?php echo $survey->title; ?></h3>
+            <p><?php echo $survey->description; ?></p>
 
-<h3><?php echo $survey->title; ?></h3>
-<p><?php echo $survey->description; ?></p>
-
-<?php echo form_open(get_uri("nps/submit"), array("id" => "nps-form")); ?>
-<input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
-<?php foreach ($questions as $question) { ?>
-    <div class="nps-question">
-        <label><?php echo $question->title; ?></label>
-        <div class="nps-scale">
-            <?php for ($i = 0; $i <= 10; $i++) { ?>
-                <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>
-            <?php } ?>
+            <?php echo view('Polls\\Views\\nps\\form', ['survey' => $survey, 'questions' => $questions, 'show_submit' => true]); ?>
         </div>
     </div>
-<?php } ?>
-<button type="submit" class="btn btn-primary"><?php echo app_lang('submit'); ?></button>
-<?php echo form_close(); ?>
+</div>
 
-<?php if ($embedded) { ?>
-<script>
-var form = document.getElementById('nps-form');
-form.addEventListener('submit', function (e) {
-    e.preventDefault();
-    fetch(form.action, {method: 'POST', body: new FormData(form)})
-        .then(function (response) { return response.json(); })
-        .then(function (data) {
-            form.innerHTML = data.message;
-        });
-});
-</script>
-</body>
-</html>
-<?php } else { ?>
 <script type="text/javascript">
     $(document).ready(function () {
         $("#nps-form").appForm({
@@ -60,7 +19,3 @@ form.addEventListener('submit', function (e) {
         });
     });
 </script>
-        </div>
-    </div>
-</div>
-<?php } ?>

--- a/plugins/Polls/Views/nps/report.php
+++ b/plugins/Polls/Views/nps/report.php
@@ -4,6 +4,10 @@
             <h1><?php echo $survey->title; ?></h1>
         </div>
         <div class="p15">
+            <div class="mb15">
+                <strong><?php echo app_lang('embed'); ?>:</strong>
+                <pre class="mt5">&lt;iframe src="<?php echo get_uri('nps/embed/' . $survey->id); ?>"&gt;&lt;/iframe&gt;</pre>
+            </div>
             <p><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($nps_score, 2); ?></p>
             <ul class="list-group">
                 <li class="list-group-item"><?php echo app_lang('promoters'); ?>: <?php echo $promoters; ?></li>


### PR DESCRIPTION
## Summary
- Extract reusable NPS survey form view and include question IDs and survey ID
- Add lightweight embed view and script for auto-submitting scores
- Expose iframe embed code on NPS report page for admins

## Testing
- `php -l plugins/Polls/Views/nps/form.php`
- `php -l plugins/Polls/Views/nps/embed.php`
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Views/nps/public_survey.php`
- `php -l plugins/Polls/Views/nps/report.php`
- `node --check assets/js/nps_embed.js`


------
https://chatgpt.com/codex/tasks/task_e_68b73fa0fda88332aa2606c0e7fa7bb1