### PR TITLE
Add NPS summary reporting and chart

### DIFF
--- a/plugins/Polls/Models/Nps_responses_model.php
+++ b/plugins/Polls/Models/Nps_responses_model.php
@@ -31,6 +31,21 @@ class Nps_responses_model extends \App\Models\Crud_model {
         return $this->db->query($sql);
     }
 
+    function get_summary($survey_id) {
+        $responses_table = $this->db->prefixTable('nps_responses');
+        $questions_table = $this->db->prefixTable('nps_questions');
+
+        $survey_id = $this->_get_clean_value($survey_id);
+
+        $sql = "SELECT $responses_table.question_id, $responses_table.score, COUNT($responses_table.id) AS total, $questions_table.title
+                FROM $responses_table
+                LEFT JOIN $questions_table ON $questions_table.id = $responses_table.question_id
+                WHERE $responses_table.survey_id=$survey_id
+                GROUP BY $responses_table.question_id, $responses_table.score, $questions_table.title
+                ORDER BY $responses_table.question_id ASC, $responses_table.score ASC";
+        return $this->db->query($sql);
+    }
+
     function save_score($data) {
         return $this->ci_save($data);
     }

--- a/plugins/Polls/Views/nps/report.php
+++ b/plugins/Polls/Views/nps/report.php
@@ -8,12 +8,36 @@
                 <strong><?php echo app_lang('embed'); ?>:</strong>
                 <pre class="mt5">&lt;iframe src="<?php echo get_uri('nps/embed/' . $survey->id); ?>"&gt;&lt;/iframe&gt;</pre>
             </div>
-            <p><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($nps_score, 2); ?></p>
-            <ul class="list-group">
-                <li class="list-group-item"><?php echo app_lang('promoters'); ?>: <?php echo $promoters; ?></li>
-                <li class="list-group-item"><?php echo app_lang('passives'); ?>: <?php echo $passives; ?></li>
-                <li class="list-group-item"><?php echo app_lang('detractors'); ?>: <?php echo $detractors; ?></li>
-            </ul>
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th><?php echo app_lang('category'); ?></th>
+                        <th><?php echo app_lang('count'); ?></th>
+                        <th><?php echo app_lang('percentage'); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><?php echo app_lang('promoters'); ?></td>
+                        <td><?php echo $promoters; ?></td>
+                        <td><?php echo round($promoters_percent, 2); ?>%</td>
+                    </tr>
+                    <tr>
+                        <td><?php echo app_lang('passives'); ?></td>
+                        <td><?php echo $passives; ?></td>
+                        <td><?php echo round($passives_percent, 2); ?>%</td>
+                    </tr>
+                    <tr>
+                        <td><?php echo app_lang('detractors'); ?></td>
+                        <td><?php echo $detractors; ?></td>
+                        <td><?php echo round($detractors_percent, 2); ?>%</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p class="mt20"><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($nps_score, 2); ?></p>
+
+            <?php echo view("Polls\\Views\\polls\\vote_pie_chart", array("poll_answers" => $poll_answers)); ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add `get_summary` method to retrieve NPS scores grouped by question
- compute promoters, passives, detractors and NPS percentages in report controller
- display counts, percentages and a pie chart in NPS report view

## Testing
- `php -l plugins/Polls/Models/Nps_responses_model.php`
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Views/nps/report.php`


------
https://chatgpt.com/codex/tasks/task_e_68b740c0fc1c83328f98d9e3b569c133