### PR TITLE
Add NPS survey question management

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -91,6 +91,38 @@ class Nps extends \App\Controllers\Security_Controller {
         }
     }
 
+    // list questions of a survey
+    function questions($survey_id = 0) {
+        validate_numeric_value($survey_id);
+
+        $survey = $this->Nps_surveys_model->get_one($survey_id);
+        if (!$survey || !$survey->id) {
+            show_404();
+        }
+
+        $view_data = array(
+            "survey" => $survey,
+            "questions" => $this->Nps_questions_model->get_details(array("survey_id" => $survey_id))->getResult()
+        );
+
+        return $this->template->rander("Polls\\Views\\nps\\questions", $view_data);
+    }
+
+    // delete a question
+    function delete_question() {
+        $this->validate_submitted_data(array(
+            "id" => "required|numeric"
+        ));
+
+        $id = $this->request->getPost('id');
+
+        if ($this->Nps_questions_model->delete($id)) {
+            echo json_encode(array("success" => true, 'message' => app_lang('record_deleted')));
+        } else {
+            echo json_encode(array("success" => false, 'message' => app_lang('record_cannot_be_deleted')));
+        }
+    }
+
     // show NPS report
     function report($survey_id = 0) {
         $survey = $this->Nps_surveys_model->get_one($survey_id);

--- a/plugins/Polls/Language/english/default_lang.php
+++ b/plugins/Polls/Language/english/default_lang.php
@@ -32,6 +32,8 @@ $lang["polls_all_members"] = "All members";
 $lang["polls_specific_members"] = "Specific members";
 $lang["polls_choose_members"] = "Choose members";
 
+$lang["manage_questions"] = "Manage questions";
+
 /* settings */
 $lang["polls_who_can_manage_polls"] = "Who can manage polls?";
 $lang["polls_who_can_view_polls"] = "Who can view polls?";

--- a/plugins/Polls/Views/nps/index.php
+++ b/plugins/Polls/Views/nps/index.php
@@ -12,6 +12,7 @@
                     <tr>
                         <th><?php echo app_lang("title"); ?></th>
                         <th><?php echo app_lang("status"); ?></th>
+                        <th class="text-center option w100"><i data-feather='menu' class='icon-16'></i></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -19,6 +20,9 @@
                         <tr>
                             <td><?php echo anchor(get_uri("nps/report/" . $survey->id), $survey->title); ?></td>
                             <td><?php echo $survey->status; ?></td>
+                            <td class="text-center option">
+                                <?php echo anchor(get_uri("nps/questions/" . $survey->id), app_lang('manage_questions')); ?>
+                            </td>
                         </tr>
                     <?php } ?>
                 </tbody>

--- a/plugins/Polls/Views/nps/questions.php
+++ b/plugins/Polls/Views/nps/questions.php
@@ -1,0 +1,33 @@
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="page-title clearfix">
+            <h1><?php echo $survey->title; ?></h1>
+            <div class="title-button-group">
+                <?php echo modal_anchor(get_uri("nps/question_form"), "<i data-feather='plus' class='icon-16'></i>" . app_lang('add'), array("class" => "btn btn-default", "title" => app_lang('add'), "data-post-survey_id" => $survey->id)); ?>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table class="display dataTable" width="100%">
+                <thead>
+                    <tr>
+                        <th><?php echo app_lang("question"); ?></th>
+                        <th class="text-center option w100"><i data-feather='menu' class='icon-16'></i></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($questions as $question) { ?>
+                        <tr>
+                            <td><?php echo $question->title; ?></td>
+                            <td class="text-center option">
+                                <?php
+                                echo modal_anchor(get_uri("nps/question_form"), "<i data-feather='edit' class='icon-16'></i>", array("class" => "edit", "title" => app_lang('edit'), "data-post-id" => $question->id, "data-post-survey_id" => $survey->id));
+                                echo js_anchor("<i data-feather='x' class='icon-16'></i>", array("title" => app_lang('delete'), "class" => "delete", "data-id" => $question->id, "data-action-url" => get_uri("nps/delete_question"), "data-action" => "delete-confirmation"));
+                                ?>
+                            </td>
+                        </tr>
+                    <?php } ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add "Manage Questions" action to NPS survey list
- implement questions listing and deletion in NPS controller
- provide question management view and translation string

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Views/nps/index.php`
- `php -l plugins/Polls/Views/nps/questions.php`
- `php -l plugins/Polls/Language/english/default_lang.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b743f294408332bbbc0b2c0a44bd1a