### PR TITLE
Validate NPS responses and remove redundant question inputs

### DIFF
--- a/plugins/Polls/Views/nps/form.php
+++ b/plugins/Polls/Views/nps/form.php
@@ -3,7 +3,6 @@
 <?php foreach ($questions as $question) { ?>
     <div class="nps-question">
         <label><?php echo $question->title; ?></label>
-        <input type="hidden" name="question_id[]" value="<?php echo $question->id; ?>" />
         <div class="nps-scale">
             <?php for ($i = 0; $i <= 10; $i++) { ?>
                 <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>


### PR DESCRIPTION
## Summary
- Validate NPS survey submissions by ensuring scores exist for all questions before saving
- Remove unused `question_id[]` hidden inputs from the NPS form

## Testing
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Views/nps/form.php`


------
https://chatgpt.com/codex/tasks/task_e_68b74d25c4f483328a6f8b4af0d59109