### PR TITLE
Declare Votes_model property in Polls controller

### DIFF
--- a/plugins/Polls/Controllers/Polls.php
+++ b/plugins/Polls/Controllers/Polls.php
@@ -6,6 +6,7 @@ class Polls extends \App\Controllers\Security_Controller {
 
     protected $Polls_model;
     protected $Poll_answers_model;
+    protected $Votes_model;
     protected $Votes_table;
     protected $Poll_settings_model;
 


### PR DESCRIPTION
## Summary
- add missing Votes_model property so constructor assignment works

## Testing
- `php -l plugins/Polls/Controllers/Polls.php`


------
https://chatgpt.com/codex/tasks/task_e_68b752d47b6c8332bfbace5c80624bd1