### PR TITLE
Guard poll permission settings against empty values

### DIFF
--- a/plugins/Polls/Controllers/Polls.php
+++ b/plugins/Polls/Controllers/Polls.php
@@ -34,13 +34,13 @@ class Polls extends \App\Controllers\Security_Controller {
     private function can_create_poll() {
         $poll_access_permission = get_poll_setting("access_all_members");
 
-        $access_poll_specific_permission = unserialize(get_poll_setting("access_poll_specific"));
-        if (!$access_poll_specific_permission) {
-            $access_poll_specific_permission = array();
-        }
+        $raw = get_poll_setting('access_poll_specific');
+        $access_poll_specific_permission = $raw ? unserialize($raw) : [];
 
         $poll_access_permission_specific = get_array_value($access_poll_specific_permission, "manage_polls_specific");
-        $poll_access_specific = explode(',', $poll_access_permission_specific);
+        $poll_access_specific = $poll_access_permission_specific
+            ? explode(',', $poll_access_permission_specific)
+            : [];
 
         //check settings if user is an admin or has permission to access poll
         if ($this->login_user->is_admin || $poll_access_permission || in_array($this->login_user->id, $poll_access_specific)) {
@@ -52,14 +52,13 @@ class Polls extends \App\Controllers\Security_Controller {
     private function can_only_view_poll() {
         $poll_view_permission = get_poll_setting("view_all_members");
 
-        $view_poll_specific_permission = unserialize(get_poll_setting("view_poll_specific"));
-
-        if (!$view_poll_specific_permission) {
-            $view_poll_specific_permission = array();
-        }
+        $raw = get_poll_setting('view_poll_specific');
+        $view_poll_specific_permission = $raw ? unserialize($raw) : [];
 
         $poll_view_permission_specific = get_array_value($view_poll_specific_permission, "view_polls_specific");
-        $poll_view_specific = explode(',', $poll_view_permission_specific);
+        $poll_view_specific = $poll_view_permission_specific
+            ? explode(',', $poll_view_permission_specific)
+            : [];
 
         if ($poll_view_permission || in_array($this->login_user->id, $poll_view_specific)) {
             return true;


### PR DESCRIPTION
## Summary
- Safely handle poll-specific permission settings by checking for raw values before unserializing
- Conditionally explode permission strings to avoid warnings when values are empty

## Testing
- `php -l plugins/Polls/Controllers/Polls.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75456ac788332bc528dd5baeadf7d