### PR TITLE
Use fallback for NPS question title

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -58,7 +58,7 @@ class Nps extends \App\Controllers\Security_Controller {
     function question_form() {
         $id = $this->request->getPost('id');
         $survey_id = $this->request->getPost('survey_id');
-        $view_data['model_info'] = $this->Nps_questions_model->get_one($id);
+        $view_data['model_info'] = (object) $this->Nps_questions_model->get_one($id);
         $view_data['survey_id'] = $survey_id;
         return $this->template->view('Polls\\Views\\nps\\question_form', $view_data);
     }

--- a/plugins/Polls/Views/nps/question_form.php
+++ b/plugins/Polls/Views/nps/question_form.php
@@ -4,7 +4,7 @@
     <input type="hidden" name="survey_id" value="<?php echo $survey_id; ?>" />
     <div class="form-group">
         <label><?php echo app_lang("question"); ?></label>
-        <?php echo form_input(array("id" => "title", "name" => "title", "value" => $model_info->title, "class" => "form-control", "required" => "required")); ?>
+        <?php echo form_input(array("id" => "title", "name" => "title", 'value' => $model_info->title ?? '', "class" => "form-control", "required" => "required")); ?>
     </div>
 </div>
 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Allow NPS question form to default to empty title when no model data exists
- Ensure NPS controller always provides an object for question form data

## Testing
- `php -l plugins/Polls/Views/nps/question_form.php`
- `php -l plugins/Polls/Controllers/Nps.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7578c735c833293de0aaf07f57dd1