### PR TITLE
Fix NPS question field and summary

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -58,7 +58,7 @@ class Nps extends \App\Controllers\Security_Controller {
     function question_form() {
         $id = $this->request->getPost('id');
         $survey_id = $this->request->getPost('survey_id');
-        $view_data['model_info'] = (object) $this->Nps_questions_model->get_one($id);
+        $view_data['model_info'] = $this->Nps_questions_model->get_one($id);
         $view_data['survey_id'] = $survey_id;
         return $this->template->view('Polls\\Views\\nps\\question_form', $view_data);
     }
@@ -74,7 +74,7 @@ class Nps extends \App\Controllers\Security_Controller {
         $id = $this->request->getPost('id');
         $data = array(
             "survey_id" => $this->request->getPost('survey_id'),
-            "title" => $this->request->getPost('title'),
+            "question_text" => $this->request->getPost('title'),
             "sort_order" => $this->request->getPost('sort_order')
         );
 

--- a/plugins/Polls/Models/Nps_responses_model.php
+++ b/plugins/Polls/Models/Nps_responses_model.php
@@ -37,11 +37,11 @@ class Nps_responses_model extends \App\Models\Crud_model {
 
         $survey_id = $this->_get_clean_value($survey_id);
 
-        $sql = "SELECT $responses_table.question_id, $responses_table.score, COUNT($responses_table.id) AS total, $questions_table.title
+        $sql = "SELECT $responses_table.question_id, $responses_table.score, COUNT($responses_table.id) AS total, $questions_table.question_text AS title
                 FROM $responses_table
                 LEFT JOIN $questions_table ON $questions_table.id = $responses_table.question_id
                 WHERE $responses_table.survey_id=$survey_id
-                GROUP BY $responses_table.question_id, $responses_table.score, $questions_table.title
+                GROUP BY $responses_table.question_id, $responses_table.score, $questions_table.question_text
                 ORDER BY $responses_table.question_id ASC, $responses_table.score ASC";
         return $this->db->query($sql);
     }

--- a/plugins/Polls/Views/nps/form.php
+++ b/plugins/Polls/Views/nps/form.php
@@ -2,7 +2,7 @@
 <input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
 <?php foreach ($questions as $question) { ?>
     <div class="nps-question">
-        <label><?php echo $question->title; ?></label>
+        <label><?php echo $question->question_text; ?></label>
         <div class="nps-scale">
             <?php for ($i = 0; $i <= 10; $i++) { ?>
                 <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>

--- a/plugins/Polls/Views/nps/question_form.php
+++ b/plugins/Polls/Views/nps/question_form.php
@@ -4,7 +4,7 @@
     <input type="hidden" name="survey_id" value="<?php echo $survey_id; ?>" />
     <div class="form-group">
         <label><?php echo app_lang("question"); ?></label>
-        <?php echo form_input(array("id" => "title", "name" => "title", 'value' => $model_info->title ?? '', "class" => "form-control", "required" => "required")); ?>
+        <?php echo form_input(array("id" => "title", "name" => "title", 'value' => $model_info->question_text ?? '', "class" => "form-control", "required" => "required")); ?>
     </div>
 </div>
 <div class="modal-footer">

--- a/plugins/Polls/Views/nps/questions.php
+++ b/plugins/Polls/Views/nps/questions.php
@@ -17,7 +17,7 @@
                 <tbody>
                     <?php foreach ($questions as $question) { ?>
                         <tr>
-                            <td><?php echo $question->title; ?></td>
+                            <td><?php echo $question->question_text; ?></td>
                             <td class="text-center option">
                                 <?php
                                 echo modal_anchor(get_uri("nps/question_form"), "<i data-feather='edit' class='icon-16'></i>", array("class" => "edit", "title" => app_lang('edit'), "data-post-id" => $question->id, "data-post-survey_id" => $survey->id));


### PR DESCRIPTION
## Summary
- Use `question_text` field for NPS questions in controller, views and summary query
- Align question form and list views with new field to prevent undefined property warnings

## Testing
- `php -l plugins/Polls/Views/nps/question_form.php`
- `php -l plugins/Polls/Views/nps/form.php`
- `php -l plugins/Polls/Views/nps/questions.php`
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Models/Nps_responses_model.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75adf8af883329ccca3d1173f163d