### PR TITLE
Fix NPS embed route 404

### DIFF
--- a/plugins/Polls/Config/Routes.php
+++ b/plugins/Polls/Config/Routes.php
@@ -11,12 +11,15 @@ $routes->post('polls/(:any)', 'Polls::$1', $polls_namespace);
 $routes->get('polls/(:any)', 'Polls::$1', $polls_namespace);
 
 $routes->get('nps', 'Nps::index', $polls_namespace);
+
+// public routes should be defined before catch-all to prevent overrides
+$routes->get('nps/s/(:num)', 'Nps_public::view/$1', $polls_namespace);
+$routes->get('nps/embed/(:num)', 'Nps_public::embed/$1', $polls_namespace);
+$routes->post('nps/submit', 'Nps_public::submit', $polls_namespace);
+
+// internal NPS routes
 $routes->post('nps/(:any)', 'Nps::$1', $polls_namespace);
 $routes->get('nps/(:any)', 'Nps::$1', $polls_namespace);
-
-$routes->get('nps/s/(:num)', 'Nps_public::view/$1', $polls_namespace);
-$routes->post('nps/submit', 'Nps_public::submit', $polls_namespace);
-$routes->get('nps/embed/(:num)', 'Nps_public::embed/$1', $polls_namespace);
 
 $routes->get('poll_settings', 'Poll_settings::index', $polls_namespace);
 $routes->post('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);


### PR DESCRIPTION
## Summary
- Reorder NPS routes so public embed path isn't overridden by catch-all routing

## Testing
- `php -l plugins/Polls/Config/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b75c8dc0f88332b5d7060eaf6cd2bb