### PR TITLE
Add submit button and styling to embedded NPS surveys

### DIFF
--- a/assets/js/nps_embed.js
+++ b/assets/js/nps_embed.js
@@ -4,16 +4,15 @@ document.addEventListener('DOMContentLoaded', function () {
         return;
     }
 
-    form.addEventListener('change', function (e) {
-        if (e.target && e.target.name && e.target.name.indexOf('score') === 0) {
-            fetch(form.action, {
-                method: 'POST',
-                body: new FormData(form)
-            }).then(function (response) {
-                return response.json();
-            }).then(function (data) {
-                form.innerHTML = data.message;
-            });
-        }
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        fetch(form.action, {
+            method: 'POST',
+            body: new FormData(form)
+        }).then(function (response) {
+            return response.json();
+        }).then(function (data) {
+            form.innerHTML = data.message;
+        });
     });
 });

--- a/plugins/Polls/Views/nps/embed.php
+++ b/plugins/Polls/Views/nps/embed.php
@@ -4,13 +4,20 @@
     <meta charset="utf-8" />
     <title><?php echo $survey->title; ?></title>
     <style>
-        body {font-family: Arial, sans-serif; padding: 15px;}
-        .nps-scale label {margin-right: 6px;}
-        .nps-question {margin-bottom: 15px;}
+        body {font-family: Arial, sans-serif; padding: 20px; background: #f7f7f7; color: #333;}
+        .nps-form {max-width: 420px; margin: auto; text-align: center; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1);}
+        .nps-question {margin-bottom: 20px;}
+        .nps-scale {display: flex; justify-content: space-between; margin-top: 10px;}
+        .nps-option {display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; transition: background 0.2s, color 0.2s;}
+        .nps-option input {display: none;}
+        .nps-option span {display: block; width: 100%; line-height: 32px;}
+        .nps-option input:checked + span {background: #007bff; color: #fff; border-color: #007bff;}
+        .nps-submit-button {margin-top: 10px; padding: 8px 16px; background: #007bff; color: #fff; border: none; border-radius: 4px; cursor: pointer;}
+        .nps-submit-button:hover {background: #0056b3;}
     </style>
 </head>
 <body>
-    <?php echo view('Polls\\Views\\nps\\form', ['survey' => $survey, 'questions' => $questions, 'show_submit' => false]); ?>
+    <?php echo view('Polls\\Views\\nps\\form', ['survey' => $survey, 'questions' => $questions, 'show_submit' => true]); ?>
     <script src="<?php echo base_url('assets/js/nps_embed.js'); ?>"></script>
 </body>
 </html>

--- a/plugins/Polls/Views/nps/form.php
+++ b/plugins/Polls/Views/nps/form.php
@@ -1,16 +1,20 @@
-<?php echo form_open(get_uri("nps/submit"), array("id" => "nps-form")); ?>
+<?php echo form_open(get_uri("nps/submit"), ["id" => "nps-form", "class" => "nps-form"]); ?>
 <input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
 <?php foreach ($questions as $question) { ?>
     <div class="nps-question">
-        <label><?php echo $question->question_text; ?></label>
+        <label class="nps-question-text"><?php echo $question->question_text; ?></label>
         <div class="nps-scale">
             <?php for ($i = 0; $i <= 10; $i++) { ?>
-                <label><input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required> <?php echo $i; ?></label>
+                <label class="nps-option">
+                    <input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required>
+                    <span><?php echo $i; ?></span>
+                </label>
             <?php } ?>
         </div>
     </div>
 <?php } ?>
-<?php if(isset($show_submit) && $show_submit){ ?>
-    <button type="submit" class="btn btn-primary"><?php echo app_lang('submit'); ?></button>
+<?php if (isset($show_submit) && $show_submit) { ?>
+    <button type="submit" class="btn btn-primary nps-submit-button"><?php echo app_lang('submit'); ?></button>
 <?php } ?>
 <?php echo form_close(); ?>
+


### PR DESCRIPTION
## Summary
- Style embedded NPS survey with centered layout, styled scale options, and blue submit button
- Ensure embedded survey renders a submit button by default
- Submit NPS responses via form submission instead of change events

## Testing
- `php -l plugins/Polls/Views/nps/form.php`
- `php -l plugins/Polls/Views/nps/embed.php`
- `node --check assets/js/nps_embed.js`


------
https://chatgpt.com/codex/tasks/task_e_68b75fcd65e483328c3dd5d0cb76a7f5