### PR TITLE
Improve NPS success message

### DIFF
--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -75,7 +75,10 @@ class Nps_public extends \App\Controllers\App_Controller {
             $this->Nps_responses_model->save_score($data);
         }
 
-        echo json_encode(["success" => true, "message" => app_lang("thank_you_for_your_feedback")]);
+        echo json_encode([
+            "success" => true,
+            "message" => view("Polls\\Views\\nps\\thank_you")
+        ]);
     }
 
     // lightweight view for iframe embedding

--- a/plugins/Polls/Views/nps/thank_you.php
+++ b/plugins/Polls/Views/nps/thank_you.php
@@ -1,0 +1,4 @@
+<div class="text-center p20">
+    <i data-feather="check-circle" class="icon-16 text-success me-2"></i>
+    <?php echo app_lang("thank_you_for_your_feedback"); ?>
+</div>


### PR DESCRIPTION
## Summary
- Replace plain text response with dedicated `thank_you` view for NPS submissions
- Add styled thank-you message view to show a UI-friendly response

## Testing
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Views/nps/thank_you.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76318f90c833292a2ab7ead70c935