### PR TITLE
Revamp NPS survey form layout and add comment support

### DIFF
--- a/assets/css/nps_form.css
+++ b/assets/css/nps_form.css
@@ -1,0 +1,19 @@
+body {font-family: Arial, sans-serif; background: #f7f7f7; color: #333;}
+.nps-form {max-width: 300px; margin: 20px auto; text-align: center; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1);}
+.nps-logo img {max-width: 80px; margin-bottom: 15px;}
+.nps-question {margin-bottom: 20px;}
+.nps-question-text {font-weight: 600; display: block; margin-bottom: 15px;}
+.nps-scale {display: flex; justify-content: space-between;}
+.nps-option {flex: 1; margin: 0 2px;}
+.nps-option input {display: none;}
+.nps-option span {display: block; padding: 6px 0; border-radius: 4px; color: #fff; font-size: 12px; cursor: pointer;}
+.nps-option.nps-0 span, .nps-option.nps-1 span, .nps-option.nps-2 span {background: #ff6b6b;}
+.nps-option.nps-3 span, .nps-option.nps-4 span {background: #ffa94d;}
+.nps-option.nps-5 span, .nps-option.nps-6 span {background: #ffd43b; color: #000;}
+.nps-option.nps-7 span, .nps-option.nps-8 span {background: #94d82d;}
+.nps-option.nps-9 span, .nps-option.nps-10 span {background: #38d9a9;}
+.nps-option input:checked + span {box-shadow: 0 0 0 2px #333;}
+.nps-scale-labels {display: flex; justify-content: space-between; font-size: 12px; margin-top: 8px;}
+.nps-comment {width: 100%; margin-top: 10px; min-height: 60px; border: 1px solid #ccc; border-radius: 4px; padding: 6px; resize: vertical;}
+.nps-submit-button {margin-top: 15px; padding: 8px 16px; background: #007bff; color: #fff; border: none; border-radius: 4px; cursor: pointer; width: 100%;}
+.nps-submit-button:hover {background: #0056b3;}

--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -55,6 +55,7 @@ class Nps_public extends \App\Controllers\App_Controller {
         }
 
         $scores = $this->request->getPost("score");
+        $comments = $this->request->getPost("comment");
         $question_ids = array_map(function($q) { return $q->id; }, $this->Nps_questions_model->get_details(["survey_id" => $survey_id])->getResult());
         $submitted_ids = $scores && is_array($scores) ? array_map('intval', array_keys($scores)) : [];
         $missing_questions = array_diff($question_ids, $submitted_ids);
@@ -69,6 +70,7 @@ class Nps_public extends \App\Controllers\App_Controller {
                 "survey_id" => $survey_id,
                 "question_id" => $question_id,
                 "score" => $score,
+                "comment" => $comments[$question_id] ?? "",
                 "token" => $token,
                 "created_at" => get_current_utc_time()
             ];

--- a/plugins/Polls/Language/english/default_lang.php
+++ b/plugins/Polls/Language/english/default_lang.php
@@ -54,5 +54,6 @@ $lang["promoters"] = "Promoters";
 $lang["passives"] = "Passives";
 $lang["detractors"] = "Detractors";
 $lang["embed"] = "Embed";
+$lang["additional_comments"] = "Additional comments";
 
 return $lang;

--- a/plugins/Polls/Views/nps/embed.php
+++ b/plugins/Polls/Views/nps/embed.php
@@ -3,18 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title><?php echo $survey->title; ?></title>
-    <style>
-        body {font-family: Arial, sans-serif; padding: 20px; background: #f7f7f7; color: #333;}
-        .nps-form {max-width: 420px; margin: auto; text-align: center; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1);}
-        .nps-question {margin-bottom: 20px;}
-        .nps-scale {display: flex; justify-content: space-between; margin-top: 10px;}
-        .nps-option {display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; transition: background 0.2s, color 0.2s;}
-        .nps-option input {display: none;}
-        .nps-option span {display: block; width: 100%; line-height: 32px;}
-        .nps-option input:checked + span {background: #007bff; color: #fff; border-color: #007bff;}
-        .nps-submit-button {margin-top: 10px; padding: 8px 16px; background: #007bff; color: #fff; border: none; border-radius: 4px; cursor: pointer;}
-        .nps-submit-button:hover {background: #0056b3;}
-    </style>
+    <link rel="stylesheet" href="<?php echo base_url('assets/css/nps_form.css'); ?>" />
 </head>
 <body>
     <?php echo view('Polls\\Views\\nps\\form', ['survey' => $survey, 'questions' => $questions, 'show_submit' => true]); ?>

--- a/plugins/Polls/Views/nps/form.php
+++ b/plugins/Polls/Views/nps/form.php
@@ -1,20 +1,28 @@
 <?php echo form_open(get_uri("nps/submit"), ["id" => "nps-form", "class" => "nps-form"]); ?>
-<input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
-<?php foreach ($questions as $question) { ?>
-    <div class="nps-question">
-        <label class="nps-question-text"><?php echo $question->question_text; ?></label>
-        <div class="nps-scale">
-            <?php for ($i = 0; $i <= 10; $i++) { ?>
-                <label class="nps-option">
-                    <input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required>
-                    <span><?php echo $i; ?></span>
-                </label>
-            <?php } ?>
-        </div>
+    <div class="nps-logo">
+        <img src="<?php echo get_logo_url(); ?>" alt="Logo">
     </div>
-<?php } ?>
-<?php if (isset($show_submit) && $show_submit) { ?>
-    <button type="submit" class="btn btn-primary nps-submit-button"><?php echo app_lang('submit'); ?></button>
-<?php } ?>
+    <input type="hidden" name="survey_id" value="<?php echo $survey->id; ?>" />
+    <?php foreach ($questions as $question) { ?>
+        <div class="nps-question">
+            <label class="nps-question-text"><?php echo $question->question_text; ?></label>
+            <div class="nps-scale">
+                <?php for ($i = 0; $i <= 10; $i++) { ?>
+                    <label class="nps-option nps-<?php echo $i; ?>">
+                        <input type="radio" name="score[<?php echo $question->id; ?>]" value="<?php echo $i; ?>" required>
+                        <span><?php echo $i; ?></span>
+                    </label>
+                <?php } ?>
+            </div>
+            <div class="nps-scale-labels">
+                <span class="nps-label-left">&#128577; 0 - NOT LIKELY</span>
+                <span class="nps-label-right">10 - VERY LIKELY &#128515;</span>
+            </div>
+            <textarea name="comment[<?php echo $question->id; ?>]" class="nps-comment" placeholder="<?php echo app_lang('additional_comments'); ?>"></textarea>
+        </div>
+    <?php } ?>
+    <?php if (isset($show_submit) && $show_submit) { ?>
+        <button type="submit" class="nps-submit-button"><?php echo app_lang('submit'); ?></button>
+    <?php } ?>
 <?php echo form_close(); ?>
 

--- a/plugins/Polls/Views/nps/public_survey.php
+++ b/plugins/Polls/Views/nps/public_survey.php
@@ -1,3 +1,4 @@
+<link rel="stylesheet" href="<?php echo base_url('assets/css/nps_form.css'); ?>" />
 <div id="page-content" class="page-wrapper clearfix">
     <div class="card">
         <div class="card-body">

--- a/plugins/Polls/install/database.sql
+++ b/plugins/Polls/install/database.sql
@@ -66,6 +66,7 @@ CREATE TABLE IF NOT EXISTS `nps_responses`(
     `survey_id` INT(11) NOT NULL,
     `question_id` INT(11) NOT NULL,
     `score` TINYINT(4) NOT NULL,
+    `comment` TEXT NULL,
     `token` VARCHAR(255) NOT NULL,
     `created_at` DATETIME NOT NULL,
     PRIMARY KEY(`id`)

--- a/plugins/Polls/updates/2024_06_15_add_nps_tables.sql
+++ b/plugins/Polls/updates/2024_06_15_add_nps_tables.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS `nps_responses`(
     `survey_id` INT(11) NOT NULL,
     `question_id` INT(11) NOT NULL,
     `score` TINYINT(4) NOT NULL,
+    `comment` TEXT NULL,
     `token` VARCHAR(255) NOT NULL,
     `created_at` DATETIME NOT NULL,
     PRIMARY KEY(`id`)

--- a/plugins/Polls/updates/2024_07_01_add_nps_response_comment.sql
+++ b/plugins/Polls/updates/2024_07_01_add_nps_response_comment.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `nps_responses` ADD `comment` TEXT NULL AFTER `score`;


### PR DESCRIPTION
## Summary
- Modernize NPS form with logo, compact styling and comment textarea
- Persist optional comments with new DB column and update script
- Centralize styles in a reusable CSS file

## Testing
- `php -l plugins/Polls/Views/nps/form.php`
- `php -l plugins/Polls/Views/nps/embed.php`
- `php -l plugins/Polls/Views/nps/public_survey.php`
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Language/english/default_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_68b764dac3a8833296847952d22fb80b