### PR TITLE
Add comments and PDF export to NPS report

### DIFF
--- a/app/Helpers/general_helper.php
+++ b/app/Helpers/general_helper.php
@@ -985,6 +985,45 @@ if (!function_exists('prepare_order_pdf')) {
 }
 
 /**
+ * Prepare NPS report PDF
+ *
+ * @param array $data
+ * @param string $mode
+ * @return void|string
+ */
+if (!function_exists('prepare_nps_report_pdf')) {
+
+    function prepare_nps_report_pdf($data, $mode = "download") {
+        $pdf = new Pdf();
+        $pdf->setPrintHeader(false);
+        $pdf->setPrintFooter(false);
+        $pdf->AddPage();
+
+        if ($data) {
+            $data["mode"] = clean_data($mode);
+            $data["is_pdf"] = true;
+            $html = view("Polls\\Views\\nps\\report", $data);
+            if ($mode !== "html") {
+                $pdf->writeHTML($html, true, false, true, false, '');
+            }
+
+            $survey = get_array_value($data, "survey");
+            $pdf_file_name = "nps-report-" . $survey->id . ".pdf";
+
+            if ($mode === "download") {
+                $pdf->Output($pdf_file_name, "D");
+            } else if ($mode === "view") {
+                $pdf->SetTitle($pdf_file_name);
+                $pdf->Output($pdf_file_name, "I");
+                exit;
+            } else if ($mode === "html") {
+                return $html;
+            }
+        }
+    }
+}
+
+/**
  * 
  * get invoice number
  * @param Int $invoice_id

--- a/plugins/Polls/Views/nps/report.php
+++ b/plugins/Polls/Views/nps/report.php
@@ -2,6 +2,11 @@
     <div class="card">
         <div class="page-title clearfix">
             <h1><?php echo $survey->title; ?></h1>
+            <?php if (!isset($is_pdf)) { ?>
+                <div class="title-button-group">
+                    <?php echo anchor(get_uri("nps/download_pdf/" . $survey->id), "<i data-feather='download' class='icon-16'></i> " . app_lang('download_pdf'), array("class" => "btn btn-default")); ?>
+                </div>
+            <?php } ?>
         </div>
         <div class="p15">
             <div class="mb15">
@@ -37,7 +42,9 @@
 
             <p class="mt20"><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($nps_score, 2); ?></p>
 
-            <?php echo view("Polls\\Views\\polls\\vote_pie_chart", array("poll_answers" => $poll_answers)); ?>
+            <?php if (!isset($is_pdf)) {
+                echo view("Polls\\Views\\polls\\vote_pie_chart", array("poll_answers" => $poll_answers));
+            } ?>
 
             <?php if (!empty($questions_summary)) { ?>
                 <div class="mt30">
@@ -96,7 +103,29 @@
 
                         <p class="mt20"><strong><?php echo app_lang('nps_score'); ?>:</strong> <?php echo round($question['nps_score'], 2); ?></p>
 
-                        <?php echo view("Polls\\Views\\polls\\vote_pie_chart", array("poll_answers" => $question['poll_answers'], "chart_id" => "vote-status-chart-" . $question['id'])); ?>
+                        <?php if (!isset($is_pdf)) {
+                            echo view("Polls\\Views\\polls\\vote_pie_chart", array("poll_answers" => $question['poll_answers'], "chart_id" => "vote-status-chart-" . $question['id']));
+                        } ?>
+
+                        <?php if (isset($comments_by_question[$question['id']])) { ?>
+                            <h5 class="mt30"><?php echo app_lang('comments'); ?></h5>
+                            <table class="table table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th><?php echo app_lang('score'); ?></th>
+                                        <th><?php echo app_lang('comment'); ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($comments_by_question[$question['id']] as $response) { ?>
+                                        <tr>
+                                            <td><?php echo $response->score; ?></td>
+                                            <td><?php echo nl2br($response->comment); ?></td>
+                                        </tr>
+                                    <?php } ?>
+                                </tbody>
+                            </table>
+                        <?php } ?>
                     <?php } ?>
                 </div>
             <?php } ?>


### PR DESCRIPTION
## Summary
- Show NPS response comments in survey reports
- Allow exporting NPS reports to PDF

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Views/nps/report.php`
- `php -l app/Helpers/general_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7706194ec8332a5dec17bb37ab300