### PR TITLE
Fix NPS survey submission and PDF export errors

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -240,7 +240,10 @@ class Nps extends \App\Controllers\Security_Controller {
             show_404();
         }
 
-        prepare_nps_report_pdf($view_data, $mode);
+        // ensure the helper with PDF utilities is available
+        helper('general');
+
+        \prepare_nps_report_pdf($view_data, $mode);
     }
 }
 

--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -42,10 +42,16 @@ class Nps_public extends \App\Controllers\App_Controller {
         ]);
 
         $survey_id = $this->request->getPost("survey_id");
-        \Config\Services::session();
+
+        // start session and get a consistent token for the visitor
+        $session = \Config\Services::session();
         $token = session_id();
         if (!$token) {
-            $token = bin2hex(random_bytes(16));
+            $token = $session->get('nps_token');
+            if (!$token) {
+                $token = bin2hex(random_bytes(16));
+                $session->set('nps_token', $token);
+            }
         }
 
         $existing = $this->Nps_responses_model->get_details(["survey_id" => $survey_id, "token" => $token])->getRow();


### PR DESCRIPTION
## Summary
- Stabilize session token generation for NPS public submissions
- Load PDF helper and call global `prepare_nps_report_pdf` for NPS reports

## Testing
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Controllers/Nps.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7747d28488332a1d112e0b4c61ede