### PR TITLE
Harden NPS session and PDF export handling

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -243,7 +243,11 @@ class Nps extends \App\Controllers\Security_Controller {
         // ensure the helper with PDF utilities is available
         helper('general');
 
-        \prepare_nps_report_pdf($view_data, $mode);
+        if (function_exists('prepare_nps_report_pdf')) {
+            \prepare_nps_report_pdf($view_data, $mode);
+        } else {
+            show_404();
+        }
     }
 }
 

--- a/plugins/Polls/Controllers/Nps_public.php
+++ b/plugins/Polls/Controllers/Nps_public.php
@@ -45,7 +45,11 @@ class Nps_public extends \App\Controllers\App_Controller {
 
         // start session and get a consistent token for the visitor
         $session = \Config\Services::session();
-        $token = session_id();
+        if (is_callable([$session, 'getId'])) {
+            $token = $session->getId();
+        } else {
+            $token = session_id();
+        }
         if (!$token) {
             $token = $session->get('nps_token');
             if (!$token) {


### PR DESCRIPTION
## Summary
- Retrieve a visitor token using `Session::getId()` when available with fallbacks for legacy environments
- Safeguard NPS PDF export by loading the general helper and verifying `prepare_nps_report_pdf` exists

## Testing
- `php -l plugins/Polls/Controllers/Nps_public.php`
- `php -l plugins/Polls/Controllers/Nps.php`


------
https://chatgpt.com/codex/tasks/task_e_68b776aef88483329399283950c81dcb