### PR TITLE
Fix NPS report PDF export 404

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -243,7 +243,7 @@ class Nps extends \App\Controllers\Security_Controller {
         // ensure the helper with PDF utilities is available
         helper('general');
 
-        if (function_exists('prepare_nps_report_pdf')) {
+        if (function_exists('\\prepare_nps_report_pdf')) {
             \prepare_nps_report_pdf($view_data, $mode);
         } else {
             show_404();


### PR DESCRIPTION
## Summary
- correctly check for global `prepare_nps_report_pdf` function when exporting NPS report

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`


------
https://chatgpt.com/codex/tasks/task_e_68b77f487eb88332b745921d61acc96c