### PR TITLE
Fix NPS report PDF export

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -243,8 +243,8 @@ class Nps extends \App\Controllers\Security_Controller {
         // ensure the helper with PDF utilities is available
         helper('general');
 
-        if (function_exists('\\prepare_nps_report_pdf')) {
-            \prepare_nps_report_pdf($view_data, $mode);
+        if (function_exists('prepare_nps_report_pdf')) {
+            prepare_nps_report_pdf($view_data, $mode);
         } else {
             show_404();
         }


### PR DESCRIPTION
## Summary
- ensure NPS PDF export uses the helper function without a leading namespace prefix

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l app/Helpers/general_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b784045514833285fa144b4f2d77aa