### PR TITLE
Fix NPS PDF report route

### DIFF
--- a/plugins/Polls/Config/Routes.php
+++ b/plugins/Polls/Config/Routes.php
@@ -20,6 +20,8 @@ $routes->post('nps/submit', 'Nps_public::submit', $polls_namespace);
 // internal NPS routes
 $routes->post('nps/(:any)', 'Nps::$1', $polls_namespace);
 $routes->get('nps/(:any)', 'Nps::$1', $polls_namespace);
+$routes->post('nps/(:any)/(:any)', 'Nps::$1/$2', $polls_namespace);
+$routes->get('nps/(:any)/(:any)', 'Nps::$1/$2', $polls_namespace);
 
 $routes->get('poll_settings', 'Poll_settings::index', $polls_namespace);
 $routes->post('poll_settings/(:any)', 'Poll_settings::$1', $polls_namespace);


### PR DESCRIPTION
## Summary
- allow NPS routes to handle an extra URI segment so reports like PDF export resolve correctly

## Testing
- `php -l plugins/Polls/Config/Routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7861254a48332856fb0e02f10cad1