### PR TITLE
Fix NPS report PDF generation

### DIFF
--- a/app/Helpers/general_helper.php
+++ b/app/Helpers/general_helper.php
@@ -985,46 +985,7 @@ if (!function_exists('prepare_order_pdf')) {
 }
 
 /**
- * Prepare NPS report PDF
  *
- * @param array $data
- * @param string $mode
- * @return void|string
- */
-if (!function_exists('prepare_nps_report_pdf')) {
-
-    function prepare_nps_report_pdf($data, $mode = "download") {
-        $pdf = new Pdf();
-        $pdf->setPrintHeader(false);
-        $pdf->setPrintFooter(false);
-        $pdf->AddPage();
-
-        if ($data) {
-            $data["mode"] = clean_data($mode);
-            $data["is_pdf"] = true;
-            $html = view("Polls\\Views\\nps\\report", $data);
-            if ($mode !== "html") {
-                $pdf->writeHTML($html, true, false, true, false, '');
-            }
-
-            $survey = get_array_value($data, "survey");
-            $pdf_file_name = "nps-report-" . $survey->id . ".pdf";
-
-            if ($mode === "download") {
-                $pdf->Output($pdf_file_name, "D");
-            } else if ($mode === "view") {
-                $pdf->SetTitle($pdf_file_name);
-                $pdf->Output($pdf_file_name, "I");
-                exit;
-            } else if ($mode === "html") {
-                return $html;
-            }
-        }
-    }
-}
-
-/**
- * 
  * get invoice number
  * @param Int $invoice_id
  * @return string

--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -241,7 +241,7 @@ class Nps extends \App\Controllers\Security_Controller {
         }
 
         // ensure the helper with PDF utilities is available
-        helper('general');
+        helper(['general', 'nps']);
 
         if (function_exists('prepare_nps_report_pdf')) {
             prepare_nps_report_pdf($view_data, $mode);

--- a/plugins/Polls/Helpers/nps_helper.php
+++ b/plugins/Polls/Helpers/nps_helper.php
@@ -36,3 +36,42 @@ if (!function_exists('nps_save_score')) {
     }
 }
 
+/**
+ * Prepare NPS report PDF
+ *
+ * @param array $data
+ * @param string $mode
+ * @return void|string
+ */
+if (!function_exists('prepare_nps_report_pdf')) {
+
+    function prepare_nps_report_pdf($data, $mode = "download") {
+        $pdf = new \App\Libraries\Pdf();
+        $pdf->setPrintHeader(false);
+        $pdf->setPrintFooter(false);
+        $pdf->AddPage();
+
+        if ($data) {
+            $data["mode"] = clean_data($mode);
+            $data["is_pdf"] = true;
+            $html = view("Polls\\Views\\nps\\report", $data);
+            if ($mode !== "html") {
+                $pdf->writeHTML($html, true, false, true, false, '');
+            }
+
+            $survey = get_array_value($data, "survey");
+            $pdf_file_name = "nps-report-" . $survey->id . ".pdf";
+
+            if ($mode === "download") {
+                $pdf->Output($pdf_file_name, "D");
+            } else if ($mode === "view") {
+                $pdf->SetTitle($pdf_file_name);
+                $pdf->Output($pdf_file_name, "I");
+                exit;
+            } else if ($mode === "html") {
+                return $html;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Move `prepare_nps_report_pdf` into NPS plugin helper
- Load NPS helper in controller to ensure PDF utilities are available
- Remove NPS PDF function from generic helper

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Helpers/nps_helper.php`
- `php -l app/Helpers/general_helper.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7901edb6c8332b9aff6dfd6055313