### PR TITLE
Format chart numbers and reorder Closed Won status

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1548,10 +1548,27 @@ class Leads extends Security_Controller {
         $volume_by_status_labels = array();
         $volume_by_status_data = array();
         $volume_by_status_colors = array();
+        $closed_won = array();
         foreach ($volume_status_rows as $row) {
-            $volume_by_status_labels[] = $row->status_title ? $row->status_title : app_lang('unknown');
-            $volume_by_status_data[] = $row->volume * 1;
-            $volume_by_status_colors[] = $row->status_color ? $row->status_color : '#808080';
+            $title = $row->status_title ? $row->status_title : app_lang('unknown');
+            $data = $row->volume * 1;
+            $color = $row->status_color ? $row->status_color : '#808080';
+
+            // Keep "Closed Won" statuses at the end
+            if (stripos($title, 'Closed Won') !== false) {
+                $closed_won = array('label' => $title, 'data' => $data, 'color' => $color);
+                continue;
+            }
+
+            $volume_by_status_labels[] = $title;
+            $volume_by_status_data[] = $data;
+            $volume_by_status_colors[] = $color;
+        }
+
+        if ($closed_won) {
+            $volume_by_status_labels[] = $closed_won['label'];
+            $volume_by_status_data[] = $closed_won['data'];
+            $volume_by_status_colors[] = $closed_won['color'];
         }
 
         $view_data["volume_by_status_labels"] = json_encode($volume_by_status_labels);

--- a/app/Views/clients/reports/margin_volume_chart.php
+++ b/app/Views/clients/reports/margin_volume_chart.php
@@ -49,7 +49,12 @@
                     }],
                     yAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
-                        ticks: {fontColor: '#898fa9'}
+                        ticks: {
+                            fontColor: '#898fa9',
+                            callback: function (value) {
+                                return value.toLocaleString();
+                            }
+                        }
                     }]
                 }
             }
@@ -77,7 +82,12 @@
                     }],
                     yAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
-                        ticks: {fontColor: '#898fa9'}
+                        ticks: {
+                            fontColor: '#898fa9',
+                            callback: function (value) {
+                                return value.toLocaleString();
+                            }
+                        }
                     }]
                 }
             }

--- a/app/Views/clients/reports/volume_by_source_chart.php
+++ b/app/Views/clients/reports/volume_by_source_chart.php
@@ -39,7 +39,12 @@
                     }],
                     yAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
-                        ticks: {fontColor: '#898fa9'}
+                        ticks: {
+                            fontColor: '#898fa9',
+                            callback: function (value) {
+                                return value.toLocaleString();
+                            }
+                        }
                     }]
                 }
             }

--- a/app/Views/clients/reports/volume_by_status_chart.php
+++ b/app/Views/clients/reports/volume_by_status_chart.php
@@ -41,7 +41,12 @@
                     }],
                     yAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
-                        ticks: {fontColor: '#898fa9'}
+                        ticks: {
+                            fontColor: '#898fa9',
+                            callback: function (value) {
+                                return value.toLocaleString();
+                            }
+                        }
                     }]
                 }
             }

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -325,7 +325,12 @@
                             ticks: {autoSkip: false}
                         }],
                     yAxes: [{
-                            ticks: {beginAtZero: true}
+                            ticks: {
+                                beginAtZero: true,
+                                callback: function (value) {
+                                    return value.toLocaleString();
+                                }
+                            }
                         }]
                 }
             }


### PR DESCRIPTION
## Summary
- Format volume and margin bar charts with thousands separators
- Move Closed Won status to end of status volume chart

## Testing
- `php -l app/Controllers/Leads.php`
- `php -l app/Views/clients/reports/volume_by_status_chart.php`
- `php -l app/Views/clients/reports/volume_by_source_chart.php`
- `php -l app/Views/clients/reports/margin_volume_chart.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`
- `npm test` *(fails: Could not read package.json)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b84f83f5a48332bc7b9fc4c7bad67d