### PR TITLE
Format bar chart data labels with thousands separators

### DIFF
--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -320,6 +320,14 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                plugins: {
+                    datalabels: {
+                        color: '#333',
+                        formatter: function(value) {
+                            return value.toLocaleString();
+                        }
+                    }
+                },
                 scales: {
                     xAxes: [{
                             ticks: {autoSkip: false}


### PR DESCRIPTION
## Summary
- add Chart.js datalabel formatter to show thousands separators on lead status bar chart

## Testing
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_68b853c8c6e0833298aa47a536b181ca