### PR TITLE
Fix NPS survey delete and icon

### DIFF
--- a/plugins/Polls/Controllers/Nps.php
+++ b/plugins/Polls/Controllers/Nps.php
@@ -54,6 +54,21 @@ class Nps extends \App\Controllers\Security_Controller {
         }
     }
 
+    // delete survey
+    function delete() {
+        $this->validate_submitted_data(array(
+            "id" => "required|numeric"
+        ));
+
+        $id = $this->request->getPost('id');
+
+        if ($this->Nps_surveys_model->delete($id)) {
+            echo json_encode(array("success" => true, 'message' => app_lang('record_deleted')));
+        } else {
+            echo json_encode(array("success" => false, 'message' => app_lang('record_cannot_be_deleted')));
+        }
+    }
+
     // load question add/edit modal
     function question_form() {
         $id = $this->request->getPost('id');

--- a/plugins/Polls/Views/nps/index.php
+++ b/plugins/Polls/Views/nps/index.php
@@ -21,7 +21,10 @@
                             <td><?php echo anchor(get_uri("nps/report/" . $survey->id), $survey->title); ?></td>
                             <td><?php echo $survey->status; ?></td>
                             <td class="text-center option">
-                                <?php echo anchor(get_uri("nps/questions/" . $survey->id), app_lang('manage_questions')); ?>
+                                <?php
+                                echo anchor(get_uri("nps/questions/" . $survey->id), "<i data-feather='list' class='icon-16'></i>", array("title" => app_lang('manage_questions')));
+                                echo js_anchor("<i data-feather='x' class='icon-16'></i>", array("title" => app_lang('delete'), "class" => "delete", "data-id" => $survey->id, "data-action-url" => get_uri("nps/delete"), "data-action" => "delete-confirmation"));
+                                ?>
                             </td>
                         </tr>
                     <?php } ?>


### PR DESCRIPTION
## Summary
- enable deletion of NPS surveys
- replace manage questions text with icon and add delete icon

## Testing
- `php -l plugins/Polls/Controllers/Nps.php`
- `php -l plugins/Polls/Views/nps/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b856db922c8332b1246a3af743ef69