### PR TITLE
Add thousands separators to client report chart labels

### DIFF
--- a/app/Views/clients/reports/volume_by_source_chart.php
+++ b/app/Views/clients/reports/volume_by_source_chart.php
@@ -32,6 +32,14 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                plugins: {
+                    datalabels: {
+                        color: '#333',
+                        formatter: function(value) {
+                            return parseInt(value, 10).toLocaleString();
+                        }
+                    }
+                },
                 scales: {
                     xAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
@@ -42,7 +50,7 @@
                         ticks: {
                             fontColor: '#898fa9',
                             callback: function (value) {
-                                return value.toLocaleString();
+                                return Number(value).toLocaleString();
                             }
                         }
                     }]

--- a/app/Views/clients/reports/volume_by_status_chart.php
+++ b/app/Views/clients/reports/volume_by_status_chart.php
@@ -34,6 +34,14 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                plugins: {
+                    datalabels: {
+                        color: '#333',
+                        formatter: function(value) {
+                            return parseInt(value, 10).toLocaleString();
+                        }
+                    }
+                },
                 scales: {
                     xAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
@@ -44,7 +52,7 @@
                         ticks: {
                             fontColor: '#898fa9',
                             callback: function (value) {
-                                return value.toLocaleString();
+                                return Number(value).toLocaleString();
                             }
                         }
                     }]

--- a/app/Views/leads/reports/converted_to_client_monthly_chart.php
+++ b/app/Views/leads/reports/converted_to_client_monthly_chart.php
@@ -151,7 +151,9 @@
                 plugins: {
                     datalabels: {
                         color: '#333',
-                        formatter: function(value) { return value; }
+                        formatter: function(value) {
+                            return parseInt(value, 10).toLocaleString();
+                        }
                     }
                 },
                 tooltips: {
@@ -254,7 +256,9 @@
                 plugins: {
                     datalabels: {
                         color: '#333',
-                        formatter: function(value) { return value; }
+                        formatter: function(value) {
+                            return parseInt(value, 10).toLocaleString();
+                        }
                     }
                 },
                 legend: {
@@ -288,7 +292,9 @@
                 plugins: {
                     datalabels: {
                         color: '#333',
-                        formatter: function(value) { return value; }
+                        formatter: function(value) {
+                            return parseInt(value, 10).toLocaleString();
+                        }
                     }
                 },
                 legend: {
@@ -324,7 +330,7 @@
                     datalabels: {
                         color: '#333',
                         formatter: function(value) {
-                            return value.toLocaleString();
+                            return Number(value).toLocaleString();
                         }
                     }
                 },
@@ -336,7 +342,7 @@
                             ticks: {
                                 beginAtZero: true,
                                 callback: function (value) {
-                                    return value.toLocaleString();
+                                    return Number(value).toLocaleString();
                                 }
                             }
                         }]


### PR DESCRIPTION
## Summary
- format chart labels with comma thousands separators
- ensure axis ticks use locale-aware numbering

## Testing
- `php -l app/Views/clients/reports/volume_by_status_chart.php`
- `php -l app/Views/clients/reports/volume_by_source_chart.php`
- `php -l app/Views/leads/reports/converted_to_client_monthly_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_68b87685da44833290a40528d6f6e08a