### PR TITLE
Format chart tooltips with thousands separators

### DIFF
--- a/app/Views/clients/reports/margin_volume_chart.php
+++ b/app/Views/clients/reports/margin_volume_chart.php
@@ -42,6 +42,18 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                tooltips: {
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || "";
+                            var value = tooltipItem.yLabel;
+                            if (label) {
+                                return label + ": " + Number(value).toLocaleString();
+                            }
+                            return Number(value).toLocaleString();
+                        }
+                    }
+                },
                 scales: {
                     xAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},
@@ -75,6 +87,18 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                tooltips: {
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || "";
+                            var value = tooltipItem.yLabel;
+                            if (label) {
+                                return label + ": " + Number(value).toLocaleString();
+                            }
+                            return Number(value).toLocaleString();
+                        }
+                    }
+                },
                 scales: {
                     xAxes: [{
                         gridLines: {color: 'rgba(127,127,127,0.1)'},

--- a/app/Views/clients/reports/volume_by_source_chart.php
+++ b/app/Views/clients/reports/volume_by_source_chart.php
@@ -32,6 +32,18 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                tooltips: {
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || "";
+                            var value = tooltipItem.yLabel;
+                            if (label) {
+                                return label + ": " + Number(value).toLocaleString();
+                            }
+                            return Number(value).toLocaleString();
+                        }
+                    }
+                },
                 plugins: {
                     datalabels: {
                         color: '#333',

--- a/app/Views/clients/reports/volume_by_status_chart.php
+++ b/app/Views/clients/reports/volume_by_status_chart.php
@@ -34,6 +34,18 @@
                 responsive: true,
                 maintainAspectRatio: false,
                 legend: {display: false},
+                tooltips: {
+                    callbacks: {
+                        label: function(tooltipItem, data) {
+                            var label = data.datasets[tooltipItem.datasetIndex].label || "";
+                            var value = tooltipItem.yLabel;
+                            if (label) {
+                                return label + ": " + Number(value).toLocaleString();
+                            }
+                            return Number(value).toLocaleString();
+                        }
+                    }
+                },
                 plugins: {
                     datalabels: {
                         color: '#333',


### PR DESCRIPTION
## Summary
- format client report tooltips with thousands separators for readability

## Testing
- `php -l app/Views/clients/reports/volume_by_status_chart.php`
- `php -l app/Views/clients/reports/volume_by_source_chart.php`
- `php -l app/Views/clients/reports/margin_volume_chart.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb303166688332ae9c49a8a711ee5f