### PR TITLE
Remove forced Closed Won ordering in volume chart

### DIFF
--- a/app/Controllers/Leads.php
+++ b/app/Controllers/Leads.php
@@ -1548,27 +1548,14 @@ class Leads extends Security_Controller {
         $volume_by_status_labels = array();
         $volume_by_status_data = array();
         $volume_by_status_colors = array();
-        $closed_won = array();
         foreach ($volume_status_rows as $row) {
             $title = $row->status_title ? $row->status_title : app_lang('unknown');
             $data = $row->volume * 1;
             $color = $row->status_color ? $row->status_color : '#808080';
 
-            // Keep "Closed Won" statuses at the end
-            if (stripos($title, 'Closed Won') !== false) {
-                $closed_won = array('label' => $title, 'data' => $data, 'color' => $color);
-                continue;
-            }
-
             $volume_by_status_labels[] = $title;
             $volume_by_status_data[] = $data;
             $volume_by_status_colors[] = $color;
-        }
-
-        if ($closed_won) {
-            $volume_by_status_labels[] = $closed_won['label'];
-            $volume_by_status_data[] = $closed_won['data'];
-            $volume_by_status_colors[] = $closed_won['color'];
         }
 
         $view_data["volume_by_status_labels"] = json_encode($volume_by_status_labels);


### PR DESCRIPTION
## Summary
- Show volume-by-status bars in lead status sort order
- Remove special handling that placed "Closed Won" at the end

## Testing
- `php -l app/Controllers/Leads.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb41fb761c8332a6ab45760e7c5a4c