### PR TITLE
Add configurable lead embed forms

### DIFF
--- a/app/Controllers/App_Controller.php
+++ b/app/Controllers/App_Controller.php
@@ -57,6 +57,7 @@ class App_Controller extends Controller {
     public $Notifications_model;
     public $Custom_fields_model;
     public $Estimate_forms_model;
+    public $Lead_forms_model;
     public $Estimate_requests_model;
     public $Custom_field_values_model;
     public $Estimates_model;
@@ -178,6 +179,7 @@ class App_Controller extends Controller {
             'Notifications_model',
             'Custom_fields_model',
             'Estimate_forms_model',
+            'Lead_forms_model',
             'Estimate_requests_model',
             'Custom_field_values_model',
             'Estimates_model',

--- a/app/Controllers/Collect_leads.php
+++ b/app/Controllers/Collect_leads.php
@@ -101,6 +101,12 @@ class Collect_leads extends App_Controller {
         $company_name = $this->request->getPost('company_name');
         $first_name = $this->request->getPost('first_name');
         $last_name = $this->request->getPost('last_name');
+        $source_id = (int)$this->request->getPost('lead_source_id');
+
+        //fallback to first + last name if company name is empty
+        if (!$company_name) {
+            $company_name = trim($first_name . " " . $last_name);
+        }
 
         $leads_data = array(
             "company_name" => $company_name,
@@ -112,18 +118,14 @@ class Collect_leads extends App_Controller {
             "phone" => $this->request->getPost('phone'),
             "is_lead" => 1,
             "lead_status_id" => $this->Lead_status_model->get_first_status(),
-            "lead_source_id" => $this->request->getPost("lead_source_id"),
+            "lead_source_id" => $source_id,
             "labels" => $this->request->getPost("lead_labels"),
             "created_date" => get_current_utc_time(),
             "owner_id" => $this->request->getPost("lead_owner_id") ? $this->request->getPost("lead_owner_id") : 1 //if no owner is selected, add default admin
         );
 
-        if ($company_name) {
-            $leads_data["type"] = "organization";
-        } else {
-            $leads_data["type"] = "person";
-            $leads_data["company_name"] = $first_name . " " . $last_name;
-        }
+        //determine type based on whether a company name was explicitly provided
+        $leads_data["type"] = $this->request->getPost('company_name') ? "organization" : "person";
 
         $leads_data = clean_data($leads_data);
 

--- a/app/Controllers/Lead_forms.php
+++ b/app/Controllers/Lead_forms.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Controllers;
+
+class Lead_forms extends Security_Controller {
+
+    function __construct() {
+        parent::__construct();
+        $this->init_permission_checker("lead");
+    }
+
+    function index() {
+        $this->access_only_allowed_members();
+        return $this->template->rander("collect_leads/lead_forms");
+    }
+
+    function modal_form() {
+        $this->access_only_admin_or_settings_admin();
+        $view_data["model_info"] = $this->Lead_forms_model->get_one($this->request->getPost("id"));
+
+        // prepare owners dropdown
+        $owners_dropdown = array("" => "-" . app_lang("owner") . "-");
+        $owners = $this->Users_model->get_all_where(array("user_type" => "staff", "deleted" => 0, "status" => "active"))->getResult();
+        foreach ($owners as $owner) {
+            $owners_dropdown[$owner->id] = $owner->first_name . " " . $owner->last_name;
+        }
+        $view_data["owners_dropdown"] = $owners_dropdown;
+
+        // prepare labels dropdown
+        $labels_dropdown = array();
+        $labels = $this->Labels_model->get_details(array("context" => "client"))->getResult();
+        foreach ($labels as $label) {
+            $labels_dropdown[$label->id] = $label->title;
+        }
+        $view_data["labels_dropdown"] = $labels_dropdown;
+
+        // prepare custom fields dropdown
+        $custom_fields_dropdown = array();
+        $custom_fields = $this->Custom_fields_model->get_details(array("related_to" => "leads", "show_in_embedded_form" => true))->getResult();
+        foreach ($custom_fields as $field) {
+            $field_title = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+            $custom_fields_dropdown[$field->id] = $field_title;
+        }
+        $view_data["custom_fields_dropdown"] = $custom_fields_dropdown;
+
+        return $this->template->view("collect_leads/lead_form_modal_form", $view_data);
+    }
+
+    function save() {
+        $this->access_only_admin_or_settings_admin();
+        $id = $this->request->getPost("id");
+        $data = array(
+            "title" => $this->request->getPost("title"),
+            "owner_id" => $this->request->getPost("owner_id"),
+            "lead_source_id" => $this->request->getPost("lead_source_id"),
+            "labels" => is_array($this->request->getPost("labels")) ? implode(",", $this->request->getPost("labels")) : $this->request->getPost("labels"),
+            "custom_fields" => is_array($this->request->getPost("custom_fields")) ? implode(",", $this->request->getPost("custom_fields")) : $this->request->getPost("custom_fields")
+        );
+        $save_id = $this->Lead_forms_model->ci_save($data, $id);
+        if ($save_id) {
+            echo json_encode(array("success" => true, "id" => $save_id, "data" => $this->_row_data($save_id), "message" => app_lang("record_saved")));
+        } else {
+            echo json_encode(array("success" => false, "message" => app_lang("error_occurred")));
+        }
+    }
+
+    function delete() {
+        $this->access_only_admin_or_settings_admin();
+        $id = $this->request->getPost("id");
+        if ($this->Lead_forms_model->delete($id)) {
+            echo json_encode(array("success" => true, "message" => app_lang("record_deleted")));
+        } else {
+            echo json_encode(array("success" => false, "message" => app_lang("record_cannot_be_deleted")));
+        }
+    }
+
+    function list_data() {
+        $this->access_only_allowed_members();
+        $list_data = $this->Lead_forms_model->get_details()->getResult();
+        $result = array();
+        foreach ($list_data as $data) {
+            $result[] = $this->_make_row($data);
+        }
+        echo json_encode(array("data" => $result));
+    }
+
+    private function _row_data($id) {
+        $data = $this->Lead_forms_model->get_one($id);
+        return $this->_make_row($data);
+    }
+
+    private function _make_row($data) {
+        $owner = "-";
+        if ($data->owner_id) {
+            $owner_info = $this->Users_model->get_one($data->owner_id);
+            if ($owner_info) {
+                $owner = get_team_member_profile_link($data->owner_id, $owner_info->first_name . " " . $owner_info->last_name);
+            }
+        }
+
+        $options = modal_anchor(get_uri("lead_forms/modal_form"), "<i data-feather='edit' class='icon-16'></i>", array("class" => "edit", "title" => app_lang('edit'), "data-post-id" => $data->id))
+                . js_anchor("<i data-feather='x' class='icon-16'></i>", array("title" => app_lang('delete'), "class" => "delete", "data-id" => $data->id, "data-action-url" => get_uri("lead_forms/delete"), "data-action" => "delete"));
+
+        return array($data->title, $owner, $data->lead_source_id, $data->labels, $options);
+    }
+}
+
+/* End of file Lead_forms.php */
+/* Location: ./app/controllers/Lead_forms.php */

--- a/app/Controllers/Lead_forms.php
+++ b/app/Controllers/Lead_forms.php
@@ -22,9 +22,17 @@ class Lead_forms extends Security_Controller {
         $owners_dropdown = array("" => "-" . app_lang("owner") . "-");
         $owners = $this->Users_model->get_all_where(array("user_type" => "staff", "deleted" => 0, "status" => "active"))->getResult();
         foreach ($owners as $owner) {
-            $owners_dropdown[$owner->id] = $owner->first_name . " " . $owner->last_name;
+        $owners_dropdown[$owner->id] = $owner->first_name . " " . $owner->last_name;
+    }
+    $view_data["owners_dropdown"] = $owners_dropdown;
+
+        // prepare lead sources dropdown
+        $sources_dropdown = array();
+        $sources = $this->Lead_source_model->get_details()->getResult();
+        foreach ($sources as $source) {
+            $sources_dropdown[] = array("id" => $source->id, "text" => $source->title);
         }
-        $view_data["owners_dropdown"] = $owners_dropdown;
+        $view_data["sources_dropdown"] = $sources_dropdown;
 
         // prepare labels dropdown
         $labels_dropdown = array();
@@ -98,10 +106,18 @@ class Lead_forms extends Security_Controller {
             }
         }
 
+        $source = "-";
+        if ($data->lead_source_id) {
+            $source_info = $this->Lead_source_model->get_one($data->lead_source_id);
+            if ($source_info) {
+                $source = $source_info->title;
+            }
+        }
+
         $options = modal_anchor(get_uri("lead_forms/modal_form"), "<i data-feather='edit' class='icon-16'></i>", array("class" => "edit", "title" => app_lang('edit'), "data-post-id" => $data->id))
                 . js_anchor("<i data-feather='x' class='icon-16'></i>", array("title" => app_lang('delete'), "class" => "delete", "data-id" => $data->id, "data-action-url" => get_uri("lead_forms/delete"), "data-action" => "delete"));
 
-        return array($data->title, $owner, $data->lead_source_id, $data->labels, $options);
+        return array($data->title, $owner, $source, $data->labels, $options);
     }
 }
 

--- a/app/Database/Migrations/2024-09-08-000000_CreateLeadFormsTable.php
+++ b/app/Database/Migrations/2024-09-08-000000_CreateLeadFormsTable.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateLeadFormsTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+                'auto_increment' => true
+            ],
+            'title' => [
+                'type' => 'VARCHAR',
+                'constraint' => 255,
+            ],
+            'owner_id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+                'null' => true,
+            ],
+            'lead_source_id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+                'null' => true,
+            ],
+            'labels' => [
+                'type' => 'TEXT',
+                'null' => true,
+            ],
+            'custom_fields' => [
+                'type' => 'TEXT',
+                'null' => true,
+            ],
+            'deleted' => [
+                'type' => 'TINYINT',
+                'constraint' => 1,
+                'default' => 0,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('lead_forms', true);
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('lead_forms', true);
+    }
+}
+

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -764,6 +764,10 @@ $lang["estimate_list"] = "Estimate List";
 $lang["estimate_forms"] = "Estimate Forms";
 $lang["estimate_request_forms"] = "Estimate Request Forms";
 
+$lang["lead_forms"] = "Lead forms";
+$lang["form"] = "Form";
+$lang["region"] = "Region";
+
 $lang["add_form"] = "Add form";
 $lang["edit_form"] = "Edit form";
 $lang["delete_form"] = "Delete form";

--- a/app/Libraries/Left_menu.php
+++ b/app/Libraries/Left_menu.php
@@ -68,7 +68,11 @@ class Left_menu {
             $sidebar_menu["tasks"] = array("name" => "tasks", "url" => "tasks/all_tasks", "class" => "check-circle");
 
             if (get_setting("module_lead") == "1" && ($this->ci->login_user->is_admin || $access_lead)) {
-                $sidebar_menu["leads"] = array("name" => "leads", "url" => "leads", "class" => "layers");
+                $leads_submenu = array(
+                    "lead_forms" => array("name" => "lead_forms", "url" => "lead_forms", "class" => "file")
+                );
+
+                $sidebar_menu["leads"] = array("name" => "leads", "url" => "leads", "class" => "layers", "submenu" => $leads_submenu);
             }
 
             if (get_setting("module_subscription") && ($this->ci->login_user->is_admin || $access_subscription)) {

--- a/app/Models/Lead_forms_model.php
+++ b/app/Models/Lead_forms_model.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+class Lead_forms_model extends Crud_model {
+
+    protected $table = null;
+
+    function __construct() {
+        $this->table = 'lead_forms';
+        parent::__construct($this->table);
+    }
+
+    function get_details($options = array()) {
+        $lead_forms_table = $this->db->prefixTable('lead_forms');
+
+        $where = "";
+        $id = $this->_get_clean_value($options, 'id');
+        if ($id) {
+            $where .= " AND $lead_forms_table.id=$id";
+        }
+
+        $sql = "SELECT $lead_forms_table.*
+        FROM $lead_forms_table
+        WHERE $lead_forms_table.deleted=0 $where";
+
+        return $this->db->query($sql);
+    }
+}
+

--- a/app/Views/collect_leads/embedded_code_modal_form.php
+++ b/app/Views/collect_leads/embedded_code_modal_form.php
@@ -17,6 +17,20 @@
             </div>
             <div class="form-group">
                 <div class="row">
+                    <label for="lead_form_id" class="col-md-3"><?php echo app_lang('form'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $lead_form_dropdown = array('' => "- " . app_lang('form') . " -");
+                        foreach ($lead_forms as $form) {
+                            $lead_form_dropdown[$form->id] = $form->title;
+                        }
+                        echo form_dropdown('lead_form_id', $lead_form_dropdown, '', "class='select2' id='lead_form_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
                     <label for="source" class="col-md-3"><?php echo app_lang('source'); ?></label>
                     <div class="col-md-9">
                         <?php
@@ -68,6 +82,7 @@
 
         var sourceId = "";
         var ownerId = "";
+        var formId = "";
 
         $("#lead_source_id").on("change", function() {
             sourceId = $(this).val();
@@ -79,11 +94,19 @@
             updateEmbeddedCode();
         });
 
-        function updateEmbeddedCode() {
-            var src = "<?php echo get_uri('collect_leads') . '/index/'; ?>";
-            var embeddedCode = "<?php echo $embedded; ?>";
+        $("#lead_form_id").on("change", function() {
+            formId = $(this).val();
+            updateEmbeddedCode();
+        });
 
-            if (sourceId || ownerId) {
+        function updateEmbeddedCode() {
+            var embeddedCode = "<?php echo $embedded; ?>";
+            if (formId) {
+                var iframeSrc = "<?php echo get_uri('collect_leads/form/'); ?>" + formId;
+                var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
+                $("#embedded-code").val(iframeHtml);
+            } else if (sourceId || ownerId) {
+                var src = "<?php echo get_uri('collect_leads') . '/index/'; ?>";
                 var iframeSrc = src + (sourceId ? sourceId : "0") + "/" + (ownerId ? ownerId : "0");
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -82,6 +82,12 @@ table.dataTable tbody td:first-child {
             
             <!-- 2) Keep lead_owner_id hidden if needed -->
             <input type="hidden" name="lead_owner_id" value="<?php echo $lead_owner_id; ?>" />
+            <?php if (!empty($lead_source_id)) { ?>
+                <input type="hidden" name="lead_source_id" value="<?php echo $lead_source_id; ?>" />
+            <?php } ?>
+            <?php if (!empty($lead_labels)) { ?>
+                <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
+            <?php } ?>
 
             <!-- 3) Gather hidden fields list, if applicable -->
             <?php $hidden_fields = explode(",", get_setting("hidden_fields_on_lead_embedded_form")); ?>
@@ -235,10 +241,11 @@ table.dataTable tbody td:first-child {
         </div>
     </div>
 <?php } ?>
+            <?php if (!$lead_source_id) { ?>
             <div class="form-group">
                 <label for="lead_source_id">Region</label>
                 <div>
-                    <select 
+                    <select
                         name="lead_source_id"
                         id="lead_source_id"
                         class="form-control select2"
@@ -255,6 +262,7 @@ table.dataTable tbody td:first-child {
                     </select>
                 </div>
             </div>
+            <?php } ?>
 
     
 

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -375,7 +375,7 @@ table.dataTable tbody td:first-child {
 
         function updateLeadSource() {
             var cityVal = $("#city").val().trim().toLowerCase();
-            var provinceVal = $("#state").val(); 
+            var provinceVal = $("#state").val();
 
             if(!provinceVal) {
                 $("#lead_source_id").val("").trigger("change");
@@ -423,6 +423,16 @@ table.dataTable tbody td:first-child {
             var mappedId = sourceMap[provinceVal] ? sourceMap[provinceVal] : "";
             $("#lead_source_id").val(mappedId).trigger("change");
         }
+
+        // 6) If company name is empty, populate it with first and last name on submit
+        $('#lead-form').on('submit', function() {
+            var company = $('#company_name');
+            if (!company.val().trim()) {
+                var first = $('#first_name').val().trim();
+                var last = $('#last_name').val().trim();
+                company.val((first + ' ' + last).trim());
+            }
+        });
     });
 
     // Google Places Autocomplete handled by assets/js/google_address_autocomplete.js

--- a/app/Views/collect_leads/lead_form_modal_form.php
+++ b/app/Views/collect_leads/lead_form_modal_form.php
@@ -1,0 +1,59 @@
+<?php echo form_open(get_uri("lead_forms/save"), array("id" => "lead-form", "class" => "general-form", "role" => "form")); ?>
+<div class="modal-body clearfix">
+    <input type="hidden" name="id" value="<?php echo $model_info->id; ?>" />
+    <div class="form-group">
+        <div class="row">
+            <label for="title" class="col-md-3"><?php echo app_lang('title'); ?></label>
+            <div class="col-md-9">
+                <?php echo form_input(array("id" => "title", "name" => "title", "value" => $model_info->title, "class" => "form-control", "data-rule-required" => true, "data-msg-required" => app_lang('field_required'))); ?>
+            </div>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="row">
+            <label for="owner_id" class="col-md-3"><?php echo app_lang('owner'); ?></label>
+            <div class="col-md-9">
+                <?php echo form_dropdown("owner_id", $owners_dropdown, $model_info->owner_id, "class='select2' id='owner_id'"); ?>
+            </div>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="row">
+            <label for="lead_source_id" class="col-md-3"><?php echo app_lang('region'); ?></label>
+            <div class="col-md-9">
+                <?php echo form_input(array("id" => "lead_source_id", "name" => "lead_source_id", "value" => $model_info->lead_source_id, "class" => "form-control")); ?>
+            </div>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="row">
+            <label for="labels" class="col-md-3"><?php echo app_lang('labels'); ?></label>
+            <div class="col-md-9">
+                <?php echo form_multiselect("labels[]", $labels_dropdown, ($model_info->labels ? explode(',', $model_info->labels) : array()), "class='select2' id='lead_form_labels'"); ?>
+            </div>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="row">
+            <label for="custom_fields" class="col-md-3"><?php echo app_lang('custom_fields'); ?></label>
+            <div class="col-md-9">
+                <?php echo form_multiselect("custom_fields[]", $custom_fields_dropdown, ($model_info->custom_fields ? explode(',', $model_info->custom_fields) : array()), "class='select2' id='lead_form_custom_fields'"); ?>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-default" data-bs-dismiss="modal"><span data-feather="x" class="icon-16"></span> <?php echo app_lang('close'); ?></button>
+    <button type="submit" class="btn btn-primary"><span data-feather="check-circle" class="icon-16"></span> <?php echo app_lang('save'); ?></button>
+</div>
+<?php echo form_close(); ?>
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#lead-form").appForm({
+            onSuccess: function (result) {
+                $("#lead-forms-table").appTable({newData: result.data, dataId: result.id});
+            }
+        });
+        $(".select2").select2();
+    });
+</script>

--- a/app/Views/collect_leads/lead_form_modal_form.php
+++ b/app/Views/collect_leads/lead_form_modal_form.php
@@ -21,7 +21,7 @@
         <div class="row">
             <label for="lead_source_id" class="col-md-3"><?php echo app_lang('region'); ?></label>
             <div class="col-md-9">
-                <?php echo form_input(array("id" => "lead_source_id", "name" => "lead_source_id", "value" => $model_info->lead_source_id, "class" => "form-control")); ?>
+                <?php echo view('partials/lead_source_select', ['sources_dropdown' => $sources_dropdown, 'selected' => $model_info->lead_source_id, 'id' => 'lead_source_id']); ?>
             </div>
         </div>
     </div>

--- a/app/Views/collect_leads/lead_forms.php
+++ b/app/Views/collect_leads/lead_forms.php
@@ -1,0 +1,29 @@
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card">
+        <div class="page-title clearfix">
+            <h1><?php echo app_lang('lead_forms'); ?></h1>
+            <div class="title-button-group">
+                <?php echo modal_anchor(get_uri('lead_forms/modal_form'), "<i data-feather='plus-circle' class='icon-16'></i> " . app_lang('add_form'), array("class" => "btn btn-default", "title" => app_lang('add_form'))); ?>
+            </div>
+        </div>
+        <div class="table-responsive">
+            <table id="lead-forms-table" class="display" cellspacing="0" width="100%"></table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#lead-forms-table").appTable({
+            source: '<?php echo_uri("lead_forms/list_data") ?>',
+            order: [[0, 'asc']],
+            columns: [
+                {title: "<?php echo app_lang('title'); ?>", "class": "all"},
+                {title: "<?php echo app_lang('owner'); ?>", "class": "w200"},
+                {title: "<?php echo app_lang('region'); ?>", "class": "w150"},
+                {title: "<?php echo app_lang('labels'); ?>", "class": "w200"},
+                {title: '<i data-feather="menu" class="icon-16"></i>', "class": "text-center option w100"}
+            ]
+        });
+    });
+</script>

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -1,15 +1,31 @@
 <form action="<?php echo get_uri("collect_leads/save"); ?>" role="form" method="post" accept-charset="utf-8">
 
+    <?php if (!empty($lead_source_id)) { ?>
+        <input type="hidden" name="lead_source_id" value="<?php echo $lead_source_id; ?>" />
+    <?php } ?>
+    <?php if (!empty($lead_owner_id)) { ?>
+        <input type="hidden" name="lead_owner_id" value="<?php echo $lead_owner_id; ?>" />
+    <?php } ?>
+    <?php if (!empty($lead_labels)) { ?>
+        <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
+    <?php } ?>
+
     <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" required="required" />
-    <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" >
-    <input type="text" name="last_name" id="last_name" placeholder="<?php echo app_lang('last_name'); ?>" required="required">
-    <input type="email" name="email" id="email" placeholder="<?php echo app_lang('email'); ?>" autocomplete="off">
-    <input type="text" name="address" id="address" placeholder="<?php echo app_lang('address'); ?>">
-    <input type="text" name="city" id="city" placeholder="<?php echo app_lang('city'); ?>">
-    <input type="text" name="state" id="state" placeholder="<?php echo app_lang('state'); ?>">
-    <input type="text" name="zip" id="zip" placeholder="<?php echo app_lang('zip'); ?>">
-    <input type="text" name="country" id="country" placeholder="<?php echo app_lang('country'); ?>">
-    <input type="text" name="phone" id="phone" placeholder="<?php echo app_lang('phone'); ?>">
+    <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" />
+    <input type="text" name="last_name" id="last_name" placeholder="<?php echo app_lang('last_name'); ?>" required="required" />
+    <input type="email" name="email" id="email" placeholder="<?php echo app_lang('email'); ?>" autocomplete="off" />
+    <input type="text" name="address" id="address" placeholder="<?php echo app_lang('address'); ?>" />
+    <input type="text" name="city" id="city" placeholder="<?php echo app_lang('city'); ?>" />
+    <input type="text" name="state" id="state" placeholder="<?php echo app_lang('state'); ?>" />
+    <input type="text" name="zip" id="zip" placeholder="<?php echo app_lang('zip'); ?>" />
+    <input type="text" name="country" id="country" placeholder="<?php echo app_lang('country'); ?>" />
+    <input type="text" name="phone" id="phone" placeholder="<?php echo app_lang('phone'); ?>" />
+
+    <?php if (!empty($custom_fields)) {
+        foreach ($custom_fields as $field) { ?>
+            <input type="text" name="custom_field_<?php echo $field->id; ?>" placeholder="<?php echo $field->title; ?>" />
+    <?php }
+    } ?>
 
     <button type="submit"><?php echo app_lang('submit'); ?></button>
 

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -1,4 +1,4 @@
-<form action="<?php echo get_uri("collect_leads/save"); ?>" role="form" method="post" accept-charset="utf-8">
+<form action="<?php echo get_uri("collect_leads/save"); ?>" role="form" method="post" accept-charset="utf-8" id="lead-form">
 
     <?php if (!empty($lead_source_id)) { ?>
         <input type="hidden" name="lead_source_id" value="<?php echo $lead_source_id; ?>" />
@@ -10,7 +10,7 @@
         <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
     <?php } ?>
 
-    <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" required="required" />
+    <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" />
     <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" />
     <input type="text" name="last_name" id="last_name" placeholder="<?php echo app_lang('last_name'); ?>" required="required" />
     <input type="email" name="email" id="email" placeholder="<?php echo app_lang('email'); ?>" autocomplete="off" />
@@ -30,3 +30,14 @@
     <button type="submit"><?php echo app_lang('submit'); ?></button>
 
 </form>
+
+<script>
+document.getElementById('lead-form').addEventListener('submit', function() {
+    var company = document.getElementById('company_name');
+    if (company && !company.value.trim()) {
+        var first = document.getElementById('first_name').value.trim();
+        var last = document.getElementById('last_name').value.trim();
+        company.value = (first + ' ' + last).trim();
+    }
+});
+</script>

--- a/app/Views/collect_leads/lead_html_form_code_modal_form.php
+++ b/app/Views/collect_leads/lead_html_form_code_modal_form.php
@@ -3,6 +3,48 @@
         <div class="container-fluid">
             <div class="form-group">
                 <div class="row">
+                    <label for="lead_form_id" class="col-md-3"><?php echo app_lang('form'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $lead_form_dropdown = array('' => "- " . app_lang('form') . " -");
+                        foreach ($lead_forms as $form) {
+                            $lead_form_dropdown[$form->id] = $form->title;
+                        }
+                        echo form_dropdown('lead_form_id', $lead_form_dropdown, '', "class='select2' id='lead_form_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="lead_source_id" class="col-md-3"><?php echo app_lang('source'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $lead_source = array('' => "- " . app_lang('source') . " -");
+                        foreach ($sources as $source) {
+                            $lead_source[$source->id] = $source->title;
+                        }
+                        echo form_dropdown('lead_source_id', $lead_source, '', "class='select2' id='lead_source_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="lead_owner_id" class="col-md-3"><?php echo app_lang('owner'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $lead_owner = array('' => "- " . app_lang('owner') . " -");
+                        foreach ($owners as $owner) {
+                            $lead_owner[$owner->id] = $owner->first_name . " " . $owner->last_name;
+                        }
+                        echo form_dropdown('lead_owner_id', $lead_owner, '', "class='select2' id='lead_owner_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
                     <div class="col-md-12">
                         <?php
                         echo form_textarea(array(
@@ -26,6 +68,40 @@
 <script type="text/javascript">
     $(document).ready(function () {
         $("#lead-html-form-code").addClass("h370");
+
+        $(".select2").select2();
+
+        var sourceId = "";
+        var ownerId = "";
+        var formId = "";
+
+        function updateHtmlCode() {
+            $.ajax({
+                url: "<?php echo get_uri('collect_leads/get_lead_html_form_code'); ?>",
+                type: "POST",
+                data: {lead_source_id: sourceId, lead_owner_id: ownerId, lead_form_id: formId},
+                success: function (result) {
+                    $("#lead-html-form-code").val(result);
+                }
+            });
+        }
+
+        updateHtmlCode();
+
+        $("#lead_source_id").on("change", function () {
+            sourceId = $(this).val();
+            updateHtmlCode();
+        });
+
+        $("#lead_owner_id").on("change", function () {
+            ownerId = $(this).val();
+            updateHtmlCode();
+        });
+
+        $("#lead_form_id").on("change", function () {
+            formId = $(this).val();
+            updateHtmlCode();
+        });
 
         $("#copy-button").click(function () {
             var copyTextarea = document.querySelector('#lead-html-form-code');

--- a/app/Views/settings/leads.php
+++ b/app/Views/settings/leads.php
@@ -76,7 +76,8 @@
                     echo form_checkbox("enable_embedded_form_to_get_leads", "1", get_setting("enable_embedded_form_to_get_leads") ? true : false, "id='enable_embedded_form_to_get_leads' class='form-check-input ml15'");
                     ?>
                     <span class="ml10 <?php echo get_setting('enable_embedded_form_to_get_leads') ? "" : "hide"; ?>" id="external_form_embedded_url">
-                        <?php echo modal_anchor(get_uri("collect_leads/embedded_code_modal_form"), "<i data-feather='code' class='icon-16'></i>", array("title" => app_lang('embed'), "class" => "edit external-tickets-embedded-code")) ?>
+                        <?php echo anchor(get_uri("lead_forms"), "<i data-feather='grid' class='icon-16'></i>", array("title" => app_lang('lead_forms'), "class" => "edit")); ?>
+                        <?php echo modal_anchor(get_uri("collect_leads/embedded_code_modal_form"), "<i data-feather='code' class='icon-16'></i>", array("title" => app_lang('embed'), "class" => "edit external-tickets-embedded-code")); ?>
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- introduce `Lead_forms_model` and controller to manage embed form settings like owner, region, labels and custom fields
- allow lead collection via predefined forms and hide fields based on configuration
- enhance embed code modal and views to select specific lead forms

## Testing
- `php -l app/Models/Lead_forms_model.php`
- `php -l app/Controllers/App_Controller.php`
- `php -l app/Controllers/Lead_forms.php`
- `php -l app/Controllers/Collect_leads.php`
- `php -l app/Views/collect_leads/embedded_code_modal_form.php`
- `php -l app/Views/collect_leads/index.php`
- `php -l app/Views/collect_leads/lead_forms.php`
- `php -l app/Views/collect_leads/lead_form_modal_form.php`
- `php -l app/Language/english/default_lang.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf445ce43c833288c2ba1a67673745