### PR TITLE
Add volume total calculation to clients list totals

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -297,6 +297,14 @@ function list_data() {
 
     $result["data"] = $result_data;
 
+    $sum_options = $all_options;
+    $sum_options["sum_volume_only"] = true;
+    unset($sum_options["limit"], $sum_options["skip"]);
+    $total_volume = $this->Clients_model->get_details($sum_options);
+    $result["summation"] = array(
+        "total_volume" => $total_volume
+    );
+
     echo json_encode($result);
 }
 

--- a/app/Views/clients/clients_list.php
+++ b/app/Views/clients/clients_list.php
@@ -73,6 +73,7 @@
             columns: columns,
             printColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
             xlsColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+            summation: [{column: 8, fieldName: "total_volume", dataType: 'number'}],
             ajax: {
                 dataSrc: function (data) {
                     console.log('Table Data:', data);


### PR DESCRIPTION
## Summary
- add a summation option to the clients list endpoint so the total volume is calculated with active filters
- return the total volume value with the clients list response and enable the table footer to show it

## Testing
- php -l app/Models/Clients_model.php
- php -l app/Controllers/Clients.php

------
https://chatgpt.com/codex/tasks/task_e_68c85b7ccaf08332b900b43ac8300713