### PR TITLE
Add configurable Source custom field to lead embed forms

### DIFF
--- a/app/Controllers/Lead_forms.php
+++ b/app/Controllers/Lead_forms.php
@@ -4,6 +4,8 @@ namespace App\Controllers;
 
 class Lead_forms extends Security_Controller {
 
+    private const SOURCE_CUSTOM_FIELD_ID = 265;
+
     function __construct() {
         parent::__construct();
         $this->init_permission_checker("lead");
@@ -51,18 +53,28 @@ class Lead_forms extends Security_Controller {
         }
         $view_data["custom_fields_dropdown"] = $custom_fields_dropdown;
 
+        $custom_field_meta = $this->getSourceCustomFieldMeta();
+        $view_data["source_custom_field_label"] = $custom_field_meta['label'] ?? '';
+        $view_data["source_custom_field_options"] = $custom_field_meta['options'] ?? [];
+        $view_data["source_custom_field_has_options"] = $custom_field_meta['has_options'] ?? false;
+
         return $this->template->view("collect_leads/lead_form_modal_form", $view_data);
     }
 
     function save() {
         $this->access_only_admin_or_settings_admin();
         $id = $this->request->getPost("id");
+        $custom_source_value = $this->request->getPost("custom_field_" . self::SOURCE_CUSTOM_FIELD_ID);
+        if (is_string($custom_source_value)) {
+            $custom_source_value = trim($custom_source_value);
+        }
         $data = array(
             "title" => $this->request->getPost("title"),
             "owner_id" => $this->request->getPost("owner_id"),
             "lead_source_id" => $this->request->getPost("lead_source_id"),
             "labels" => is_array($this->request->getPost("labels")) ? implode(",", $this->request->getPost("labels")) : $this->request->getPost("labels"),
-            "custom_fields" => is_array($this->request->getPost("custom_fields")) ? implode(",", $this->request->getPost("custom_fields")) : $this->request->getPost("custom_fields")
+            "custom_fields" => is_array($this->request->getPost("custom_fields")) ? implode(",", $this->request->getPost("custom_fields")) : $this->request->getPost("custom_fields"),
+            "custom_source_value" => $custom_source_value
         );
         $save_id = $this->Lead_forms_model->ci_save($data, $id);
         if ($save_id) {
@@ -118,6 +130,37 @@ class Lead_forms extends Security_Controller {
                 . js_anchor("<i data-feather='x' class='icon-16'></i>", array("title" => app_lang('delete'), "class" => "delete", "data-id" => $data->id, "data-action-url" => get_uri("lead_forms/delete"), "data-action" => "delete"));
 
         return array($data->title, $owner, $source, $data->labels, $options);
+    }
+
+    private function getSourceCustomFieldMeta(): array {
+        $field = $this->Custom_fields_model->get_one(self::SOURCE_CUSTOM_FIELD_ID);
+        if (!$field || !$field->id) {
+            return [];
+        }
+
+        $label = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+
+        $options = [];
+        if (!empty($field->options)) {
+            $raw_options = explode(',', $field->options);
+            foreach ($raw_options as $option) {
+                $option = trim($option);
+                if ($option !== '') {
+                    $options[$option] = $option;
+                }
+            }
+        }
+
+        $dropdown = [];
+        if (!empty($options)) {
+            $dropdown = array('' => "- " . $label . " -") + $options;
+        }
+
+        return [
+            'label' => $label,
+            'options' => $dropdown,
+            'has_options' => !empty($options),
+        ];
     }
 }
 

--- a/app/Database/Migrations/2024-10-05-000000_AddCustomSourceValueToLeadForms.php
+++ b/app/Database/Migrations/2024-10-05-000000_AddCustomSourceValueToLeadForms.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddCustomSourceValueToLeadForms extends Migration
+{
+    public function up()
+    {
+        if (!$this->db->fieldExists('custom_source_value', 'lead_forms')) {
+            $fields = [
+                'custom_source_value' => [
+                    'type' => 'VARCHAR',
+                    'constraint' => 255,
+                    'null' => true,
+                    'after' => 'custom_fields',
+                ],
+            ];
+
+            $this->forge->addColumn('lead_forms', $fields);
+        }
+    }
+
+    public function down()
+    {
+        if ($this->db->fieldExists('custom_source_value', 'lead_forms')) {
+            $this->forge->dropColumn('lead_forms', 'custom_source_value');
+        }
+    }
+}

--- a/app/Views/collect_leads/embedded_code_modal_form.php
+++ b/app/Views/collect_leads/embedded_code_modal_form.php
@@ -61,6 +61,27 @@
                     </div>
                 </div>
             </div>
+            <?php if (!empty($source_custom_field_label)) { ?>
+            <div class="form-group">
+                <div class="row">
+                    <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        if (!empty($source_custom_field_has_options)) {
+                            echo form_dropdown("custom_field_265", $source_custom_field_options, '', "class='select2' id='custom_field_265'");
+                        } else {
+                            echo form_input(array(
+                                "id" => "custom_field_265",
+                                "name" => "custom_field_265",
+                                "class" => "form-control",
+                                "placeholder" => $source_custom_field_label
+                            ));
+                        }
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <?php } ?>
         </div>
     </div>
     <div class="modal-footer">
@@ -83,6 +104,9 @@
         var sourceId = "";
         var ownerId = "";
         var formId = "";
+        var customFieldValue = "";
+
+        customFieldValue = $("#custom_field_265").val() || "";
 
         $("#lead_source_id").on("change", function() {
             sourceId = $(this).val();
@@ -99,15 +123,27 @@
             updateEmbeddedCode();
         });
 
+        $("#custom_field_265").on("change input", function() {
+            customFieldValue = $(this).val() || "";
+            updateEmbeddedCode();
+        });
+
         function updateEmbeddedCode() {
             var embeddedCode = "<?php echo $embedded; ?>";
+            var hasCustomField = customFieldValue !== "";
             if (formId) {
                 var iframeSrc = "<?php echo get_uri('collect_leads/form/'); ?>" + formId;
+                if (hasCustomField) {
+                    iframeSrc += (iframeSrc.indexOf('?') === -1 ? '?' : '&') + "custom_field_265=" + encodeURIComponent(customFieldValue);
+                }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);
-            } else if (sourceId || ownerId) {
+            } else if (sourceId || ownerId || hasCustomField) {
                 var src = "<?php echo get_uri('collect_leads') . '/index/'; ?>";
                 var iframeSrc = src + (sourceId ? sourceId : "0") + "/" + (ownerId ? ownerId : "0");
+                if (hasCustomField) {
+                    iframeSrc += "?custom_field_265=" + encodeURIComponent(customFieldValue);
+                }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);
             } else {

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -88,6 +88,9 @@ table.dataTable tbody td:first-child {
             <?php if (!empty($lead_labels)) { ?>
                 <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
             <?php } ?>
+            <?php if (isset($custom_field_265_value) && $custom_field_265_value !== "") { ?>
+                <input type="hidden" name="custom_field_265" value="<?php echo htmlspecialchars($custom_field_265_value); ?>" />
+            <?php } ?>
 
             <!-- 3) Gather hidden fields list, if applicable -->
             <?php $hidden_fields = explode(",", get_setting("hidden_fields_on_lead_embedded_form")); ?>

--- a/app/Views/collect_leads/lead_form_modal_form.php
+++ b/app/Views/collect_leads/lead_form_modal_form.php
@@ -33,6 +33,28 @@
             </div>
         </div>
     </div>
+    <?php if (!empty($source_custom_field_label)) { ?>
+    <div class="form-group">
+        <div class="row">
+            <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+            <div class="col-md-9">
+                <?php
+                if (!empty($source_custom_field_has_options)) {
+                    echo form_dropdown("custom_field_265", $source_custom_field_options, $model_info->custom_source_value, "class='select2' id='custom_field_265'");
+                } else {
+                    echo form_input(array(
+                        "id" => "custom_field_265",
+                        "name" => "custom_field_265",
+                        "value" => $model_info->custom_source_value,
+                        "class" => "form-control",
+                        "placeholder" => $source_custom_field_label
+                    ));
+                }
+                ?>
+            </div>
+        </div>
+    </div>
+    <?php } ?>
     <div class="form-group">
         <div class="row">
             <label for="custom_fields" class="col-md-3"><?php echo app_lang('custom_fields'); ?></label>

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -9,6 +9,9 @@
     <?php if (!empty($lead_labels)) { ?>
         <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
     <?php } ?>
+    <?php if (isset($custom_field_265_value) && $custom_field_265_value !== "") { ?>
+        <input type="hidden" name="custom_field_265" value="<?php echo htmlspecialchars($custom_field_265_value); ?>" />
+    <?php } ?>
 
     <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" />
     <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" />

--- a/app/Views/collect_leads/lead_html_form_code_modal_form.php
+++ b/app/Views/collect_leads/lead_html_form_code_modal_form.php
@@ -43,6 +43,27 @@
                     </div>
                 </div>
             </div>
+            <?php if (!empty($source_custom_field_label)) { ?>
+            <div class="form-group">
+                <div class="row">
+                    <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        if (!empty($source_custom_field_has_options)) {
+                            echo form_dropdown('custom_field_265', $source_custom_field_options, '', "class='select2' id='custom_field_265'");
+                        } else {
+                            echo form_input(array(
+                                "id" => "custom_field_265",
+                                "name" => "custom_field_265",
+                                "class" => "form-control",
+                                "placeholder" => $source_custom_field_label
+                            ));
+                        }
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <?php } ?>
             <div class="form-group">
                 <div class="row">
                     <div class="col-md-12">
@@ -74,12 +95,15 @@
         var sourceId = "";
         var ownerId = "";
         var formId = "";
+        var customFieldValue = "";
+
+        customFieldValue = $("#custom_field_265").val() || "";
 
         function updateHtmlCode() {
             $.ajax({
                 url: "<?php echo get_uri('collect_leads/get_lead_html_form_code'); ?>",
                 type: "POST",
-                data: {lead_source_id: sourceId, lead_owner_id: ownerId, lead_form_id: formId},
+                data: {lead_source_id: sourceId, lead_owner_id: ownerId, lead_form_id: formId, custom_field_265: customFieldValue},
                 success: function (result) {
                     $("#lead-html-form-code").val(result);
                 }
@@ -100,6 +124,11 @@
 
         $("#lead_form_id").on("change", function () {
             formId = $(this).val();
+            updateHtmlCode();
+        });
+
+        $("#custom_field_265").on("change input", function () {
+            customFieldValue = $(this).val() || "";
             updateHtmlCode();
         });
 


### PR DESCRIPTION
## Summary
- add Source (custom_field_265) selection to lead embed iframe and HTML code generators and include the value as a hidden field
- remove the Source custom field from rendered forms when a predefined value is used and persist selections on lead forms
- add a migration and storage column so lead forms can store the new Source custom field default

## Testing
- php -l app/Controllers/Collect_leads.php
- php -l app/Controllers/Lead_forms.php
- php -l app/Views/collect_leads/embedded_code_modal_form.php
- php -l app/Views/collect_leads/lead_html_form_code_modal_form.php
- php -l app/Views/collect_leads/lead_html_form_code.php
- php -l app/Views/collect_leads/lead_form_modal_form.php
- php -l app/Views/collect_leads/index.php
- php -l app/Database/Migrations/2024-10-05-000000_AddCustomSourceValueToLeadForms.php

------
https://chatgpt.com/codex/tasks/task_e_68c86c8bf0bc8332ad4c8bc1151b46df