### PR TITLE
Add lead conversion reporting endpoint

### DIFF
--- a/app/Controllers/Reports.php
+++ b/app/Controllers/Reports.php
@@ -34,6 +34,136 @@ class Reports extends Security_Controller {
         $view_data["redirect_to"] = $redirect_to;
         return $this->template->rander("reports/index", $view_data);
     }
+
+    public function lead_conversion() {
+        $this->_validate_lead_conversion_access();
+
+        $view_data["owners_dropdown"] = json_encode($this->_get_lead_conversion_owners_dropdown());
+        $view_data["regions_dropdown"] = json_encode($this->_get_lead_conversion_regions_dropdown());
+        $view_data["sources_dropdown"] = json_encode($this->_get_lead_conversion_sources_dropdown());
+        $view_data["statuses_dropdown"] = json_encode($this->_get_lead_conversion_status_dropdown());
+
+        return $this->template->rander("reports/lead_conversion", $view_data);
+    }
+
+    public function lead_conversion_data() {
+        $this->_validate_lead_conversion_access();
+
+        $options = array(
+            "owner_id" => $this->request->getPost("owner_id"),
+            "region_id" => $this->request->getPost("region_id"),
+            "source_value" => $this->request->getPost("source_value"),
+            "lead_status_id" => $this->request->getPost("lead_status_id"),
+            "created_start_date" => $this->request->getPost("created_start_date"),
+            "created_end_date" => $this->request->getPost("created_end_date"),
+            "migration_start_date" => $this->request->getPost("migration_start_date"),
+            "migration_end_date" => $this->request->getPost("migration_end_date")
+        );
+
+        $list_data = $this->Clients_model->get_lead_conversion_report_details($options)->getResult();
+
+        $result = array();
+        foreach ($list_data as $data) {
+            $total_leads = floatval($data->total_leads);
+            $conversions = floatval($data->conversions);
+
+            if (!$total_leads && !$conversions) {
+                continue;
+            }
+
+            $result[] = $this->_make_lead_conversion_row($data, $total_leads, $conversions);
+        }
+
+        echo json_encode(array("data" => $result));
+    }
+
+    private function _get_lead_conversion_owners_dropdown() {
+        $team_members = $this->Users_model->get_all_where(array("user_type" => "staff", "deleted" => 0, "status" => "active"))->getResult();
+        $dropdown = array(array("id" => "", "text" => "- " . app_lang("owner") . " -"));
+
+        foreach ($team_members as $member) {
+            $dropdown[] = array("id" => $member->id, "text" => trim($member->first_name . " " . $member->last_name));
+        }
+
+        return $dropdown;
+    }
+
+    private function _get_lead_conversion_regions_dropdown() {
+        $regions = $this->Lead_source_model->get_details()->getResult();
+        $dropdown = array(array("id" => "", "text" => "- " . app_lang("region") . " -"));
+
+        foreach ($regions as $region) {
+            $dropdown[] = array("id" => $region->id, "text" => $region->title);
+        }
+
+        return $dropdown;
+    }
+
+    private function _get_lead_conversion_sources_dropdown() {
+        $sources = $this->Clients_model->get_lead_conversion_source_values()->getResult();
+        $dropdown = array(array("id" => "", "text" => "- " . app_lang("source") . " -"));
+
+        foreach ($sources as $source) {
+            $dropdown[] = array("id" => $source->value, "text" => $source->value);
+        }
+
+        return $dropdown;
+    }
+
+    private function _get_lead_conversion_status_dropdown() {
+        $statuses = $this->Lead_status_model->get_details()->getResult();
+        $dropdown = array(array("id" => "", "text" => "- " . app_lang("lead_status") . " -"));
+
+        foreach ($statuses as $status) {
+            $dropdown[] = array("id" => $status->id, "text" => $status->title);
+        }
+
+        return $dropdown;
+    }
+
+    private function _make_lead_conversion_row($data, $total_leads, $conversions) {
+        $source = $data->source_value ? $data->source_value : app_lang("unknown");
+
+        $owner_name = trim($data->owner_name);
+        if ($data->owner_id) {
+            $owner = get_team_member_profile_link($data->owner_id, $owner_name ? $owner_name : app_lang("unknown"));
+        } else {
+            $owner = app_lang("unknown");
+        }
+
+        $region = $data->region_name ? $data->region_name : app_lang("unknown");
+
+        $conversion_rate = 0;
+        if ($total_leads > 0) {
+            $conversion_rate = ($conversions / $total_leads) * 100;
+        }
+
+        $average_time = "-";
+        if ($data->avg_conversion_time !== null && $data->avg_conversion_time !== "") {
+            $average_time = to_decimal_format(floatval($data->avg_conversion_time)) . " " . app_lang("days");
+        }
+
+        return array(
+            $source,
+            $owner,
+            $region,
+            to_decimal_format($total_leads),
+            to_decimal_format($conversions),
+            to_decimal_format($conversion_rate) . "%",
+            $average_time
+        );
+    }
+
+    private function _validate_lead_conversion_access() {
+        if (get_setting("module_lead") != "1") {
+            app_redirect("forbidden");
+        }
+
+        $lead_permission = get_array_value($this->login_user->permissions, "lead");
+        if (!($this->login_user->is_admin || $lead_permission === "all")) {
+            app_redirect("forbidden");
+        }
+    }
 }
 
 /* End of file Reports.php */

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -99,6 +99,7 @@ if (!function_exists('get_reports_topbar')) {
             $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
             $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
             $reports_menu[] = array("name" => "leaderboard", "url" => "clients/leaderboard", "class" => "award", "single_button" => true);
+            $reports_menu[] = array("name" => "lead_conversion_report", "url" => "reports/lead_conversion", "class" => "target", "single_button" => true);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -1922,6 +1922,10 @@ $lang["select_from_template"] = "Select from template";
 $lang["type_new_item"] = "Type new item";
 
 $lang["conversion_rate"] = "Conversion rate";
+$lang["lead_conversion_report"] = "Lead conversion report";
+$lang["average_conversion_time"] = "Average conversion time";
+$lang["conversion_date"] = "Conversion date";
+$lang["unknown"] = "Unknown";
 
 $lang["all_tasks"] = "All objectives";
 $lang["user_roles"] = "User Roles";

--- a/app/Views/reports/lead_conversion.php
+++ b/app/Views/reports/lead_conversion.php
@@ -1,0 +1,39 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="table-responsive">
+            <table id="lead-conversion-table" class="display" width="100%"></table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#lead-conversion-table").appTable({
+            source: '<?php echo_uri("reports/lead_conversion_data"); ?>',
+            filterDropdown: [
+                {name: "owner_id", class: "w200", options: <?php echo $owners_dropdown; ?>},
+                {name: "region_id", class: "w200", options: <?php echo $regions_dropdown; ?>},
+                {name: "source_value", class: "w200", options: <?php echo $sources_dropdown; ?>},
+                {name: "lead_status_id", class: "w200", options: <?php echo $statuses_dropdown; ?>}
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "created_start_date", value: ""}, endDate: {name: "created_end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true},
+                {startDate: {name: "migration_start_date", value: ""}, endDate: {name: "migration_end_date", value: ""}, label: "<?php echo app_lang('conversion_date'); ?>", showClearButton: true}
+            ],
+            columns: [
+                {title: "<?php echo app_lang('source'); ?>", class: "all"},
+                {title: "<?php echo app_lang('owner'); ?>"},
+                {title: "<?php echo app_lang('region'); ?>"},
+                {title: "<?php echo app_lang('total_leads'); ?>", class: "text-center"},
+                {title: "<?php echo app_lang('converted_to_client'); ?>", class: "text-center"},
+                {title: "<?php echo app_lang('conversion_rate'); ?>", class: "text-right"},
+                {title: "<?php echo app_lang('average_conversion_time'); ?>", class: "text-right"}
+            ],
+            order: [[3, "desc"]],
+            printColumns: [0, 1, 2, 3, 4, 5, 6],
+            xlsColumns: [0, 1, 2, 3, 4, 5, 6]
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add Clients model helpers to compute lead conversion metrics and surface distinct source filters
- add secured report actions, UI, and navigation entry for the new lead conversion report
- extend English translations used by the report filters and table labels

## Testing
- php -l app/Models/Clients_model.php
- php -l app/Controllers/Reports.php
- php -l app/Helpers/reports_helper.php
- php -l app/Language/english/custom_lang.php
- php -l app/Views/reports/lead_conversion.php

------
https://chatgpt.com/codex/tasks/task_e_68c883feb7b083328c516ced0fdc1481