### PR TITLE
Add navigation entries for client and lead reports

### DIFF
--- a/app/Controllers/Lead_conversion_reports.php
+++ b/app/Controllers/Lead_conversion_reports.php
@@ -2,7 +2,7 @@
 
 namespace App\Controllers;
 
-class LeadConversionReports extends Security_Controller {
+class Lead_conversion_reports extends Security_Controller {
 
     public function __construct() {
         parent::__construct();
@@ -329,5 +329,5 @@ class LeadConversionReports extends Security_Controller {
     }
 }
 
-/* End of file LeadConversionReports.php */
-/* Location: ./app/controllers/LeadConversionReports.php */
+/* End of file Lead_conversion_reports.php */
+/* Location: ./app/controllers/Lead_conversion_reports.php */

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -95,10 +95,22 @@ if (!function_exists('get_reports_topbar')) {
         }
 
         if (get_setting("module_lead") == "1" && ($ci->login_user->is_admin || $access_lead == "all")) {
-            $reports_menu[] = array("name" => "opportunities_graphs", "url" => "leads/converted_to_client_report", "class" => "layers", "single_button" => true);
-            $reports_menu[] = array("name" => "opportunity_data_reports", "url" => "clients/clients_report", "class" => "users", "single_button" => true);
-            $reports_menu[] = array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard", "class" => "trending-up", "single_button" => true);
-            $reports_menu[] = array("name" => "leaderboard", "url" => "clients/leaderboard", "class" => "award", "single_button" => true);
+            $client_reports_dropdown = array(
+                "client_summary" => array("name" => "client_summary", "url" => "clients/clients_report"),
+                "show_expanded_view" => array("name" => "show_expanded_view", "url" => "clients/show_expanded_view"),
+                "fill_the_funnel_leaderboard" => array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard"),
+                "leaderboard" => array("name" => "leaderboard", "url" => "clients/leaderboard")
+            );
+
+            $lead_reports_dropdown = array(
+                "converted_to_client_report" => array("name" => "converted_to_client_report", "url" => "leads/converted_to_client_report"),
+                "lead_conversion_report" => array("name" => "lead_conversion_report", "url" => "lead_conversion_reports"),
+                "client_conversion_timeline" => array("name" => "client_conversion_timeline", "url" => "lead_conversion_reports/client_timeline"),
+                "rep_conversion_rates" => array("name" => "rep_conversion_rates", "url" => "lead_conversion_reports/rep_conversion_rates")
+            );
+
+            $reports_menu["client_reports"] = array("name" => "client_reports", "url" => "clients/clients_report", "class" => "users", "dropdown_item" => $client_reports_dropdown);
+            $reports_menu["lead_reports"] = array("name" => "lead_reports", "url" => "lead_conversion_reports", "class" => "target", "dropdown_item" => $lead_reports_dropdown);
         }
 
         if (get_setting("module_ticket") == "1" && ($ci->login_user->is_admin || $access_ticket == "all")) {

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2793,6 +2793,12 @@ $lang["new_opportunities"] = "New Opportunities";
 $lang["closed_deals"] = "Closed Deals";
 $lang["total_points"] = "Total Points";
 $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderboard";
+$lang["client_reports"] = "Client reports";
+$lang["client_summary"] = "Client summary";
+$lang["lead_reports"] = "Lead reports";
+$lang["converted_to_client_report"] = "Converted to client report";
+$lang["client_conversion_timeline"] = "Client conversion timeline";
+$lang["rep_conversion_rates"] = "Rep conversion rates";
 
 $lang["opportunities_graphs"] = "Opportunities Graphs";
 $lang["opportunity_data_reports"] = "Opportunity Data Reports";

--- a/app/Libraries/Left_menu.php
+++ b/app/Libraries/Left_menu.php
@@ -205,35 +205,46 @@ class Left_menu {
 
             $reports_menu = get_reports_topbar(true);
             if (!empty($reports_menu)) {
+                $reports_submenu = array();
+                $reports_sub_pages = array(
+                    "invoices/invoices_summary",
+                    "orders/orders_summary",
+                    "projects/all_timesheets",
+                    "expenses/income_vs_expenses",
+                    "invoice_payments/payments_summary",
+                    "expenses/summary",
+                    "projects/team_members_summary",
+                    "tickets/tickets_chart_report"
+                );
+
+                if (array_key_exists("client_reports", $reports_menu)) {
+                    $reports_submenu[] = array("name" => "client_reports", "url" => "clients/clients_report");
+                    $reports_sub_pages = array_merge($reports_sub_pages, array(
+                        "clients/clients_report",
+                        "clients/show_expanded_view",
+                        "clients/fill_the_funnel_leaderboard",
+                        "clients/leaderboard"
+                    ));
+                }
+
+                if (array_key_exists("lead_reports", $reports_menu)) {
+                    $reports_submenu[] = array("name" => "lead_reports", "url" => "lead_conversion_reports");
+                    $reports_sub_pages = array_merge($reports_sub_pages, array(
+                        "leads/converted_to_client_report",
+                        "lead_conversion_reports",
+                        "lead_conversion_reports/index",
+                        "lead_conversion_reports/data",
+                        "lead_conversion_reports/client_timeline",
+                        "lead_conversion_reports/rep_conversion_rates"
+                    ));
+                }
+
                 $sidebar_menu["reports"] = array(
                     "name" => "reports",
                     "url" => "reports/index",
                     "class" => "pie-chart",
-                    "sub_pages" => array(
-                        "invoices/invoices_summary",
-                        "orders/orders_summary",
-                        "projects/all_timesheets",
-                        "expenses/income_vs_expenses",
-                        "invoice_payments/payments_summary",
-                        "expenses/summary",
-                        "projects/team_members_summary",
-                        "leads/converted_to_client_report",
-                        "clients/clients_report",
-                        "tickets/tickets_chart_report"
-                    )
-                );
-            }
-
-            if (get_setting("module_lead") == "1" && ($this->ci->login_user->is_admin || $access_lead === "all")) {
-                $sidebar_menu["lead_conversion_reports"] = array(
-                    "name" => "lead_conversion_report",
-                    "url" => "lead_conversion_reports",
-                    "class" => "target",
-                    "sub_pages" => array(
-                        "lead_conversion_reports",
-                        "lead_conversion_reports/index",
-                        "lead_conversion_reports/data"
-                    )
+                    "submenu" => $reports_submenu,
+                    "sub_pages" => array_values(array_unique($reports_sub_pages))
                 );
             }
 


### PR DESCRIPTION
## Summary
- reorganize the reports topbar so the client and lead reports are grouped under dropdown menus
- add left navigation submenu links for the client and lead report hubs and ensure the new routes are recognized
- rename the lead conversion report controller to follow underscore routing and add language strings for the new labels

## Testing
- php -l app/Helpers/reports_helper.php
- php -l app/Libraries/Left_menu.php
- php -l app/Language/english/custom_lang.php
- php -l app/Controllers/Lead_conversion_reports.php

------
https://chatgpt.com/codex/tasks/task_e_68c8ac37b68c83328244edcc763191e2