### PR TITLE
Move converted lead report under client reports

### DIFF
--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -98,12 +98,12 @@ if (!function_exists('get_reports_topbar')) {
             $client_reports_dropdown = array(
                 "client_summary" => array("name" => "client_summary", "url" => "clients/clients_report"),
                 "show_expanded_view" => array("name" => "show_expanded_view", "url" => "clients/show_expanded_view"),
+                "converted_to_client_report" => array("name" => "converted_to_client_report", "url" => "leads/converted_to_client_report"),
                 "fill_the_funnel_leaderboard" => array("name" => "fill_the_funnel_leaderboard", "url" => "clients/fill_the_funnel_leaderboard"),
                 "leaderboard" => array("name" => "leaderboard", "url" => "clients/leaderboard")
             );
 
             $lead_reports_dropdown = array(
-                "converted_to_client_report" => array("name" => "converted_to_client_report", "url" => "leads/converted_to_client_report"),
                 "lead_conversion_report" => array("name" => "lead_conversion_report", "url" => "lead_conversion_reports"),
                 "client_conversion_timeline" => array("name" => "client_conversion_timeline", "url" => "lead_conversion_reports/client_timeline"),
                 "rep_conversion_rates" => array("name" => "rep_conversion_rates", "url" => "lead_conversion_reports/rep_conversion_rates")

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2793,11 +2793,11 @@ $lang["new_opportunities"] = "New Opportunities";
 $lang["closed_deals"] = "Closed Deals";
 $lang["total_points"] = "Total Points";
 $lang["fill_the_funnel_region_leaderboard"] = "Fill the Funnel - Region Leaderboard";
-$lang["client_reports"] = "Client reports";
-$lang["client_summary"] = "Client summary";
+$lang["client_reports"] = "Opportunity reports";
+$lang["client_summary"] = "Opportunity summary";
 $lang["lead_reports"] = "Lead reports";
-$lang["converted_to_client_report"] = "Converted to client report";
-$lang["client_conversion_timeline"] = "Client conversion timeline";
+$lang["converted_to_client_report"] = "Converted to opportunity report";
+$lang["client_conversion_timeline"] = "Opportunity conversion timeline";
 $lang["rep_conversion_rates"] = "Rep conversion rates";
 
 $lang["opportunities_graphs"] = "Opportunities Graphs";

--- a/app/Libraries/Left_menu.php
+++ b/app/Libraries/Left_menu.php
@@ -222,6 +222,7 @@ class Left_menu {
                     $reports_sub_pages = array_merge($reports_sub_pages, array(
                         "clients/clients_report",
                         "clients/show_expanded_view",
+                        "leads/converted_to_client_report",
                         "clients/fill_the_funnel_leaderboard",
                         "clients/leaderboard"
                     ));
@@ -230,7 +231,6 @@ class Left_menu {
                 if (array_key_exists("lead_reports", $reports_menu)) {
                     $reports_submenu[] = array("name" => "lead_reports", "url" => "lead_conversion_reports");
                     $reports_sub_pages = array_merge($reports_sub_pages, array(
-                        "leads/converted_to_client_report",
                         "lead_conversion_reports",
                         "lead_conversion_reports/index",
                         "lead_conversion_reports/data",


### PR DESCRIPTION
## Summary
- add the converted-to-client report to the Client reports dropdown and sidebar group
- keep the lead reports menu scoped to conversion views only
- rename the related language strings so the UI says "opportunity" instead of "client"

## Testing
- php -l app/Helpers/reports_helper.php
- php -l app/Libraries/Left_menu.php
- php -l app/Language/english/custom_lang.php

------
https://chatgpt.com/codex/tasks/task_e_68c8b068e02c8332a13ba1a5a083c7e8