### PR TITLE
Align client widgets with owner-based visibility

### DIFF
--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -65,7 +65,7 @@ function get_details($options = array()) {
 
     $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
     if ($show_own_clients_only_user_id) {
-        $where .= " AND ($clients_table.created_by=$show_own_clients_only_user_id OR $clients_table.owner_id=$show_own_clients_only_user_id)";
+        $where .= " AND $clients_table.owner_id=$show_own_clients_only_user_id";
     }
 
    
@@ -552,7 +552,7 @@ function get_details($options = array()) {
         $where = "";
         $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
         if ($show_own_clients_only_user_id) {
-            $where .= " AND ($clients_table.created_by=$show_own_clients_only_user_id OR $clients_table.owner_id=$show_own_clients_only_user_id)";
+            $where .= " AND $clients_table.owner_id=$show_own_clients_only_user_id";
         }
 
         $search = $this->_get_clean_value($search);
@@ -588,7 +588,7 @@ function get_details($options = array()) {
 
         $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
         if ($show_own_clients_only_user_id) {
-            $where .= " AND $clients_table.created_by=$show_own_clients_only_user_id";
+            $where .= " AND $clients_table.owner_id=$show_own_clients_only_user_id";
         }
 
         $filter = $this->_get_clean_value($options, "filter");

--- a/app/Models/Users_model.php
+++ b/app/Models/Users_model.php
@@ -148,7 +148,7 @@ class Users_model extends Crud_model {
 
         $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
         if ($user_type == "client" && $show_own_clients_only_user_id) {
-            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.created_by=$show_own_clients_only_user_id)";
+            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.owner_id=$show_own_clients_only_user_id)";
         }
 
         $quick_filter = $this->_get_clean_value($options, "quick_filter");
@@ -369,7 +369,7 @@ class Users_model extends Crud_model {
 
         $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
         if ($user_type == "client" && $show_own_clients_only_user_id) {
-            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.created_by=$show_own_clients_only_user_id)";
+            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.owner_id=$show_own_clients_only_user_id)";
         }
 
         $client_groups = $this->_get_clean_value($options, "client_groups");
@@ -395,7 +395,7 @@ class Users_model extends Crud_model {
         $where = "";
         $show_own_clients_only_user_id = $this->_get_clean_value($options, "show_own_clients_only_user_id");
         if ($show_own_clients_only_user_id) {
-            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.created_by=$show_own_clients_only_user_id)";
+            $where .= " AND $users_table.client_id IN(SELECT $clients_table.id FROM $clients_table WHERE $clients_table.deleted=0 AND $clients_table.owner_id=$show_own_clients_only_user_id)";
         }
 
         $last_online = $this->_get_clean_value($options, "last_online");


### PR DESCRIPTION
## Summary
- ensure client list, search, and totals honour the owner_id when the "show own clients only" restriction is active
- update client contact queries to use owner-based visibility so dashboard widgets stay in sync

## Testing
- php -l app/Models/Clients_model.php
- php -l app/Models/Users_model.php

------
https://chatgpt.com/codex/tasks/task_e_68d40aa3afa0833288a9b1a54967a58c