### PR TITLE
Default lead source from owner address when adding leads

### DIFF
--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -1182,6 +1182,32 @@ function view($client_id = 0, $tab = "", $folder_id = 0) {
         }
     }
 
+    public function get_lead_source_by_owner() {
+        $this->access_only_allowed_members();
+
+        $owner_id = intval($this->request->getPost('owner_id'));
+        if (!$owner_id) {
+            echo json_encode(array("success" => true, "lead_source_id" => "", "lead_source_title" => ""));
+            return;
+        }
+
+        $lead_source_id = $this->Users_model->get_lead_source_id_from_address($owner_id);
+        $lead_source_title = "";
+
+        if ($lead_source_id) {
+            $source = $this->Lead_source_model->get_one($lead_source_id);
+            if ($source && $source->id) {
+                $lead_source_title = $source->title;
+            }
+        }
+
+        echo json_encode(array(
+            "success" => true,
+            "lead_source_id" => $lead_source_id ? $lead_source_id : "",
+            "lead_source_title" => $lead_source_title
+        ));
+    }
+
     /* load contact's social links tab view */
 
     function contact_social_links_tab($contact_id = 0) {

--- a/app/Controllers/Clients.php
+++ b/app/Controllers/Clients.php
@@ -87,33 +87,11 @@ class Clients extends Security_Controller {
         $view_data['model_info'] = $this->Clients_model->get_one($client_id);
 
         // Default lead source based on the logged in staff's address when adding
-        // a new client. The address field is checked for specific region names
-        // to determine the lead source id.
+        // a new client.
         if (!$client_id && $this->login_user->user_type === "staff" && empty($view_data['model_info']->lead_source_id)) {
-            // Fetch the address from the logged-in user's profile. The
-            // login_user object returned from get_access_info() doesn't include
-            // the address field, so retrieve the complete user record when
-            // necessary to avoid undefined property notices.
-            if (property_exists($this->login_user, 'address')) {
-                $address = trim($this->login_user->address);
-            } else {
-                $full_user_info = $this->Users_model->get_one($this->login_user->id);
-                $address = trim($full_user_info->address);
-            }
-            if ($address) {
-                $address_lower = strtolower($address);
-
-                if (strpos($address_lower, 'atlantic') !== false) {
-                    $view_data['model_info']->lead_source_id = 4;
-                } elseif (strpos($address_lower, 'pacific') !== false) {
-                    $view_data['model_info']->lead_source_id = 2;
-                } elseif (strpos($address_lower, 'ontario') !== false) {
-                    $view_data['model_info']->lead_source_id = 6;
-                } elseif (strpos($address_lower, 'prairies') !== false) {
-                    $view_data['model_info']->lead_source_id = 3;
-                } elseif (strpos($address_lower, 'quebec') !== false) {
-                    $view_data['model_info']->lead_source_id = 5;
-                }
+            $default_lead_source_id = $this->Users_model->get_lead_source_id_from_address($this->login_user->id);
+            if ($default_lead_source_id) {
+                $view_data['model_info']->lead_source_id = $default_lead_source_id;
             }
         }
         $view_data["currency_dropdown"] = $this->_get_currency_dropdown_select2_data();

--- a/app/Models/Users_model.php
+++ b/app/Models/Users_model.php
@@ -496,8 +496,49 @@ class Users_model extends Crud_model {
 
 
         $sql = "SELECT $users_table.id, CONCAT($users_table.first_name, ' ',$users_table.last_name) AS user_name
-        FROM $users_table 
+        FROM $users_table
         WHERE $users_table.deleted=0 AND $users_table.user_type='staff' AND $users_table.status='active' $where";
         return $this->db->query($sql);
+    }
+
+    /**
+     * Determine a lead source id based on the region stored in a staff
+     * member's address.
+     *
+     * @param int $user_id
+     * @return int|null
+     */
+    public function get_lead_source_id_from_address($user_id) {
+        if (!$user_id) {
+            return null;
+        }
+
+        $user = $this->get_one($user_id);
+        if (!$user || !$user->id) {
+            return null;
+        }
+
+        $address = trim($user->address);
+        if (!$address) {
+            return null;
+        }
+
+        $address = strtolower($address);
+
+        $mappings = array(
+            'atlantic' => 4,
+            'pacific' => 2,
+            'ontario' => 6,
+            'prairies' => 3,
+            'quebec' => 5
+        );
+
+        foreach ($mappings as $keyword => $source_id) {
+            if (strpos($address, $keyword) !== false) {
+                return $source_id;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Views/clients/contacts/company_info_tab.php
+++ b/app/Views/clients/contacts/company_info_tab.php
@@ -32,5 +32,46 @@
         if (window.initAddressAutocomplete) {
             window.initAddressAutocomplete('#company-form');
         }
+
+        var $ownerField = $("#owner_id");
+        var $leadSourceField = $("#client_lead_source_id");
+        var leadSourceEndpoint = "<?php echo get_uri('clients/get_lead_source_by_owner'); ?>";
+
+        function updateLeadSourceFromOwner(ownerId, forceReset) {
+            if (!ownerId) {
+                if (forceReset && $leadSourceField.find("option[value='']").length) {
+                    $leadSourceField.val("");
+                }
+                return;
+            }
+
+            $.ajax({
+                url: leadSourceEndpoint,
+                type: "POST",
+                dataType: "json",
+                data: {owner_id: ownerId},
+                success: function (response) {
+                    if (!response || !response.success) {
+                        return;
+                    }
+
+                    if (response.lead_source_id) {
+                        $leadSourceField.val(response.lead_source_id);
+                    } else if ($leadSourceField.find("option[value='']").length) {
+                        $leadSourceField.val("");
+                    }
+                }
+            });
+        }
+
+        if ($ownerField.length && $leadSourceField.length) {
+            $ownerField.on("change", function () {
+                updateLeadSourceFromOwner($(this).val(), true);
+            });
+
+            if (!$leadSourceField.val()) {
+                updateLeadSourceFromOwner($ownerField.val(), false);
+            }
+        }
     });
 </script>

--- a/app/Views/clients/modal_form.php
+++ b/app/Views/clients/modal_form.php
@@ -83,6 +83,47 @@
             $(this).trigger("submit");
         });
 
+        var $ownerField = $("#owner_id");
+        var $leadSourceField = $("#client_lead_source_id");
+        var leadSourceEndpoint = "<?php echo get_uri('clients/get_lead_source_by_owner'); ?>";
+
+        function updateLeadSourceFromOwner(ownerId, forceReset) {
+            if (!ownerId) {
+                if (forceReset && $leadSourceField.find("option[value='']").length) {
+                    $leadSourceField.val("");
+                }
+                return;
+            }
+
+            $.ajax({
+                url: leadSourceEndpoint,
+                type: "POST",
+                dataType: "json",
+                data: {owner_id: ownerId},
+                success: function (response) {
+                    if (!response || !response.success) {
+                        return;
+                    }
+
+                    if (response.lead_source_id) {
+                        $leadSourceField.val(response.lead_source_id);
+                    } else if ($leadSourceField.find("option[value='']").length) {
+                        $leadSourceField.val("");
+                    }
+                }
+            });
+        }
+
+        if ($ownerField.length && $leadSourceField.length) {
+            $ownerField.on("change", function () {
+                updateLeadSourceFromOwner($(this).val(), true);
+            });
+
+            if (!$leadSourceField.val()) {
+                updateLeadSourceFromOwner($ownerField.val(), false);
+            }
+        }
+
     });
 </script>
 

--- a/app/Views/leads/contacts/company_info_tab.php
+++ b/app/Views/leads/contacts/company_info_tab.php
@@ -30,5 +30,44 @@
         if (window.initAddressAutocomplete) {
             window.initAddressAutocomplete('#company-form');
         }
+
+        var $ownerField = $("#owner_id");
+        var $leadSourceField = $("#lead_lead_source_id");
+        var leadSourceEndpoint = "<?php echo get_uri('leads/get_lead_source_by_owner'); ?>";
+
+        function updateLeadSourceFromOwner(ownerId, forceReset) {
+            if (!ownerId) {
+                if (forceReset && $leadSourceField.find("option[value='']").length) {
+                    $leadSourceField.val("");
+                }
+                return;
+            }
+
+            $.ajax({
+                url: leadSourceEndpoint,
+                type: "POST",
+                dataType: "json",
+                data: {owner_id: ownerId},
+                success: function (response) {
+                    if (!response || !response.success) {
+                        return;
+                    }
+
+                    if (response.lead_source_id) {
+                        $leadSourceField.val(response.lead_source_id);
+                    } else if ($leadSourceField.find("option[value='']").length) {
+                        $leadSourceField.val("");
+                    }
+                }
+            });
+        }
+
+        $ownerField.on("change", function () {
+            updateLeadSourceFromOwner($(this).val(), true);
+        });
+
+        if (!$leadSourceField.val()) {
+            updateLeadSourceFromOwner($ownerField.val(), false);
+        }
     });
 </script>

--- a/app/Views/leads/lead_form_fields.php
+++ b/app/Views/leads/lead_form_fields.php
@@ -107,7 +107,20 @@
     <div class="row">
         <label for="lead_lead_source_id" class="<?php echo $label_column; ?>"><?php echo app_lang('source'); ?></label>
         <div class="<?php echo $field_column; ?>">
-            <?php echo view('partials/lead_source_select', ['lead_sources' => $sources, 'selected' => $model_info->lead_source_id, 'id' => 'lead_lead_source_id']); ?>
+            <?php
+            $lead_source_view_data = array(
+                'selected' => $model_info->lead_source_id,
+                'id' => 'lead_lead_source_id'
+            );
+
+            if (isset($sources_dropdown)) {
+                $lead_source_view_data['sources_dropdown'] = $sources_dropdown;
+            } else {
+                $lead_source_view_data['lead_sources'] = $sources;
+            }
+
+            echo view('partials/lead_source_select', $lead_source_view_data);
+            ?>
         </div>
     </div>
 </div>

--- a/app/Views/leads/modal_form.php
+++ b/app/Views/leads/modal_form.php
@@ -39,6 +39,45 @@
                 window.initAddressAutocomplete($modal[0]);
             }
         }
+
+        var $ownerField = $("#owner_id");
+        var $leadSourceField = $("#lead_lead_source_id");
+        var leadSourceEndpoint = "<?php echo get_uri('leads/get_lead_source_by_owner'); ?>";
+
+        function updateLeadSourceFromOwner(ownerId, forceReset) {
+            if (!ownerId) {
+                if (forceReset && $leadSourceField.find("option[value='']").length) {
+                    $leadSourceField.val("");
+                }
+                return;
+            }
+
+            $.ajax({
+                url: leadSourceEndpoint,
+                type: "POST",
+                dataType: "json",
+                data: {owner_id: ownerId},
+                success: function (response) {
+                    if (!response || !response.success) {
+                        return;
+                    }
+
+                    if (response.lead_source_id) {
+                        $leadSourceField.val(response.lead_source_id);
+                    } else if ($leadSourceField.find("option[value='']").length) {
+                        $leadSourceField.val("");
+                    }
+                }
+            });
+        }
+
+        $ownerField.on("change", function () {
+            updateLeadSourceFromOwner($(this).val(), true);
+        });
+
+        if (!$leadSourceField.val()) {
+            updateLeadSourceFromOwner($ownerField.val(), false);
+        }
     });
     </script>
 


### PR DESCRIPTION
## Summary
- share a helper on Users_model to derive a lead source id from a staff member's regional address
- apply the same lead source defaulting to the lead add modal and keep the client modal using the helper
- refresh the lead source selection when the owner changes in both the modal and company info tab so ownership updates pick up the new region

## Testing
- php -l app/Controllers/Clients.php
- php -l app/Controllers/Leads.php
- php -l app/Models/Users_model.php

------
https://chatgpt.com/codex/tasks/task_e_68d66abe91788332b1c5cb1d1d1e3bbe