### PR TITLE
Enhance external ticket embed customization

### DIFF
--- a/app/Views/external_tickets/embedded_code_modal_form.php
+++ b/app/Views/external_tickets/embedded_code_modal_form.php
@@ -3,14 +3,76 @@
         <div class="container-fluid">
             <div class="form-group">
                 <div class="row">
+                    <label for="embed_ticket_type_id" class="col-md-3"><?php echo app_lang('ticket_type'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $ticket_type_dropdown = array('' => "- " . app_lang('ticket_type') . " -");
+                        if (!empty($ticket_types)) {
+                            foreach ($ticket_types as $type) {
+                                $ticket_type_dropdown[$type->id] = $type->title;
+                            }
+                        }
+                        echo form_dropdown('embed_ticket_type_id', $ticket_type_dropdown, '', "class='select2' id='embed_ticket_type_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_assigned_to" class="col-md-3"><?php echo app_lang('assign_to'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $assignee_dropdown = array('' => "- " . app_lang('assign_to') . " -");
+                        if (!empty($assignees)) {
+                            foreach ($assignees as $member) {
+                                $full_name = trim($member->first_name . ' ' . $member->last_name);
+                                $assignee_dropdown[$member->id] = $full_name ? $full_name : $member->first_name;
+                            }
+                        }
+                        echo form_dropdown('embed_assigned_to', $assignee_dropdown, '', "class='select2' id='embed_assigned_to'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_ticket_labels" class="col-md-3"><?php echo app_lang('labels'); ?></label>
+                    <div class="col-md-9">
+                        <select id="embed_ticket_labels" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($labels)) {
+                                foreach ($labels as $label) {
+                                    ?><option value="<?php echo htmlspecialchars($label->id); ?>"><?php echo htmlspecialchars($label->title); ?></option><?php
+                                }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_ticket_custom_fields" class="col-md-3"><?php echo app_lang('custom_fields'); ?></label>
+                    <div class="col-md-9">
+                        <select id="embed_ticket_custom_fields" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($custom_fields)) {
+                                foreach ($custom_fields as $field) {
+                                    $field_title = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+                                    ?><option value="<?php echo htmlspecialchars($field->id); ?>"><?php echo htmlspecialchars($field_title); ?></option><?php
+                                }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
                     <div class="col-md-12">
                         <?php
                         echo form_textarea(array(
-                            "id" => "embedded-code",
-                            "name" => "embedded-code",
-                            "value" => $embedded,
-                            "class" => "form-control",
-                            "data-rich-text-editor" => false
+                            'id' => 'embedded-code',
+                            'name' => 'embedded-code',
+                            'value' => $embedded,
+                            'class' => 'form-control',
+                            'data-rich-text-editor' => false
                         ));
                         ?>
                     </div>
@@ -26,8 +88,62 @@
 
 <script type="text/javascript">
     $(document).ready(function () {
+        var $ticketType = $("#embed_ticket_type_id");
+        var $assignee = $("#embed_assigned_to");
+        var $labels = $("#embed_ticket_labels");
+        var $customFields = $("#embed_ticket_custom_fields");
+        var $embedTextarea = $("#embedded-code");
+
+        $(".select2").select2();
+
+        function buildIframeSrc() {
+            var ticketTypeId = $ticketType.val() || "";
+            var assigneeId = $assignee.val() || "";
+            var labelIds = $labels.val() || [];
+            var customFieldIds = $customFields.val() || [];
+
+            var segments = [];
+            if (ticketTypeId || assigneeId || labelIds.length) {
+                segments[0] = ticketTypeId ? ticketTypeId : 0;
+                segments[1] = assigneeId ? assigneeId : 0;
+                if (labelIds.length) {
+                    segments[2] = encodeURIComponent(labelIds.join(','));
+                }
+            }
+
+            var cleanedSegments = [];
+            for (var i = 0; i < segments.length; i++) {
+                if (typeof segments[i] !== "undefined") {
+                    cleanedSegments.push(segments[i]);
+                }
+            }
+
+            var iframeSrc = "<?php echo get_uri('external_tickets'); ?>";
+            if (cleanedSegments.length) {
+                iframeSrc = "<?php echo get_uri('external_tickets/index'); ?>" + "/" + cleanedSegments.join('/');
+            }
+
+            if (customFieldIds.length) {
+                var query = "custom_fields=" + encodeURIComponent(customFieldIds.join(','));
+                iframeSrc += (iframeSrc.indexOf('?') === -1 ? '?' : '&') + query;
+            }
+
+            return "<iframe width='768' height='840' src='" + iframeSrc + "' frameborder='0'></iframe>";
+        }
+
+        function updateEmbedCode() {
+            $embedTextarea.val(buildIframeSrc());
+        }
+
+        $ticketType.on("change", updateEmbedCode);
+        $assignee.on("change", updateEmbedCode);
+        $labels.on("change", updateEmbedCode);
+        $customFields.on("change", updateEmbedCode);
+
+        updateEmbedCode();
+
         $("#copy-button").click(function () {
-            var copyTextarea = document.querySelector('#embedded-code');
+            var copyTextarea = $embedTextarea[0];
             copyTextarea.focus();
             copyTextarea.select();
             document.execCommand('copy');

--- a/app/Views/external_tickets/index.php
+++ b/app/Views/external_tickets/index.php
@@ -94,6 +94,14 @@ table.dataTable tbody td:first-child {
         <div id="new-ticket-dropzone" class="card p15 no-border clearfix post-dropzone client-info-section" style="max-width: 100%; margin: auto;">
 
 
+            <input type="hidden" name="is_embedded_form" value="1" />
+            <?php if (!empty($selected_assignee_id)) { ?>
+                <input type="hidden" name="assigned_to" value="<?php echo htmlspecialchars($selected_assignee_id); ?>" />
+            <?php } ?>
+            <?php if (!empty($selected_label_ids)) { ?>
+                <input type="hidden" name="labels" value="<?php echo htmlspecialchars($selected_label_ids); ?>" />
+            <?php } ?>
+
             <div class="form-group">
                 <label for="title"><?php echo app_lang('title'); ?></label>
                 <div>
@@ -112,14 +120,18 @@ table.dataTable tbody td:first-child {
                 </div>
             </div>
 
-            <div class="form-group">
-                <label for="ticket_type_id"><?php echo app_lang('ticket_type'); ?></label>
-                <div>
-                    <?php
-                    echo form_dropdown("ticket_type_id", $ticket_types_dropdown, "", "class='select2'");
-                    ?>
+            <?php if (!empty($selected_ticket_type_id)) { ?>
+                <input type="hidden" name="ticket_type_id" value="<?php echo htmlspecialchars($selected_ticket_type_id); ?>" />
+            <?php } else { ?>
+                <div class="form-group">
+                    <label for="ticket_type_id"><?php echo app_lang('ticket_type'); ?></label>
+                    <div>
+                        <?php
+                        echo form_dropdown("ticket_type_id", $ticket_types_dropdown, "", "class='select2'");
+                        ?>
+                    </div>
                 </div>
-            </div>
+            <?php } ?>
     <div class="form-group">
                 <label for="email"><?php echo app_lang('your_email'); ?></label>
                 <div>


### PR DESCRIPTION
## Summary
- allow `/external_tickets` to accept preselected ticket type, assignee, label, and custom field filters for embedded usage
- add hidden field handling in the external ticket form so preselected values carry through submissions
- expand the embed-code modal with controls for ticket metadata and dynamic iframe generation

## Testing
- php -l app/Controllers/External_tickets.php
- php -l app/Views/external_tickets/index.php
- php -l app/Views/external_tickets/embedded_code_modal_form.php

------
https://chatgpt.com/codex/tasks/task_e_68dd3014b4b48332934c7e2062983e59