### PR TITLE
Render select custom fields properly in external ticket HTML embed

### DIFF
--- a/app/Controllers/Email_templates.php
+++ b/app/Controllers/Email_templates.php
@@ -143,10 +143,10 @@ class Email_templates extends Security_Controller {
 
         if (get_setting("module_ticket")) {
             $templates_array["ticket"] = array(
-                "ticket_created" => array("TICKET_ID", "TICKET_TITLE", "USER_NAME", "TICKET_CONTENT", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
-                "ticket_commented" => array("TICKET_ID", "TICKET_TITLE", "USER_NAME", "TICKET_CONTENT", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
-                "ticket_closed" => array("TICKET_ID", "TICKET_TITLE", "USER_NAME", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
-                "ticket_reopened" => array("TICKET_ID", "TICKET_TITLE", "USER_NAME", "TICKET_URL", "SIGNATURE", "LOGO_URL", "RECIPIENTS_EMAIL_ADDRESS"),
+                "ticket_created" => array("TICKET_ID", "TICKET_TITLE", "REQUEST_TYPE", "USER_NAME", "TICKET_CONTENT", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
+                "ticket_commented" => array("TICKET_ID", "TICKET_TITLE", "REQUEST_TYPE", "USER_NAME", "TICKET_CONTENT", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
+                "ticket_closed" => array("TICKET_ID", "TICKET_TITLE", "REQUEST_TYPE", "USER_NAME", "TICKET_URL", "LOGO_URL", "SIGNATURE", "RECIPIENTS_EMAIL_ADDRESS"),
+                "ticket_reopened" => array("TICKET_ID", "TICKET_TITLE", "REQUEST_TYPE", "USER_NAME", "TICKET_URL", "SIGNATURE", "LOGO_URL", "RECIPIENTS_EMAIL_ADDRESS"),
             );
         }
 

--- a/app/Controllers/External_tickets.php
+++ b/app/Controllers/External_tickets.php
@@ -90,6 +90,9 @@ class External_tickets extends App_Controller {
         validate_list_of_numbers($labels);
 
         $assigned_to = (int) $this->request->getPost('assigned_to');
+        $auto_assign_owner_input = $this->request->getPost('auto_assign_owner');
+        $auto_assign_owner_input = is_null($auto_assign_owner_input) ? '' : trim((string) $auto_assign_owner_input);
+        $should_auto_assign_owner = $auto_assign_owner_input === '0' ? false : true;
 
         $lead_source_owner_map = array(
             2 => 254,
@@ -99,7 +102,7 @@ class External_tickets extends App_Controller {
             6 => 252
         );
 
-        if (isset($lead_source_owner_map[$lead_source_id])) {
+        if ($should_auto_assign_owner && isset($lead_source_owner_map[$lead_source_id])) {
             $assigned_to = $lead_source_owner_map[$lead_source_id];
         }
         $ticket_type_id = (int) $this->request->getPost('ticket_type_id');

--- a/app/Controllers/External_tickets.php
+++ b/app/Controllers/External_tickets.php
@@ -10,18 +10,30 @@ class External_tickets extends App_Controller {
         parent::__construct();
     }
 
-    function index() { //embedded
+    function index($ticket_type_id = 0, $assignee_id = 0, $label_ids = "") { //embedded
         if (!get_setting("enable_embedded_form_to_get_tickets")) {
             show_404();
         }
+
+        validate_numeric_value($ticket_type_id);
+        validate_numeric_value($assignee_id);
+
+        $label_ids = $this->sanitizeLabelIds($label_ids);
+        $custom_field_ids = $this->sanitizeIdList($this->request->getGet('custom_fields'));
 
         $view_data['topbar'] = false;
         $view_data['left_menu'] = false;
 
         $where = array();
-        $view_data['ticket_types_dropdown'] = $this->Ticket_types_model->get_dropdown_list(array("title"), "id", $where);
+        $ticket_types_dropdown = $this->Ticket_types_model->get_dropdown_list(array("title"), "id", $where);
+        $view_data['ticket_types_dropdown'] = $ticket_types_dropdown;
 
-        $view_data["custom_fields"] = $this->Custom_fields_model->get_combined_details("tickets", 0, 0, "client")->getResult();
+        $view_data["custom_fields"] = $this->filterCustomFieldsForEmbed($this->getEmbeddableTicketCustomFields(), $custom_field_ids);
+
+        $view_data['selected_ticket_type_id'] = $ticket_type_id;
+        $view_data['selected_assignee_id'] = $assignee_id;
+        $view_data['selected_label_ids'] = $label_ids;
+        $view_data['selected_custom_field_ids'] = $custom_field_ids;
 
         return $this->template->rander("external_tickets/index", $view_data);
     }
@@ -33,24 +45,83 @@ class External_tickets extends App_Controller {
         }
 
         $this->validate_submitted_data(array(
-            "title" => "required",
             "description" => "required",
-            "email" => "required|valid_email"
+            "email" => "required|valid_email",
+            "first_name" => "required",
+            "last_name" => "required",
+            "address" => "required",
+            "city" => "required",
+            "state" => "required",
+            "zip" => "required",
+            "phone" => "required|min_length[10]",
+            "lead_source_id" => "required|numeric"
         ));
+
+        $is_embedded_form = $this->request->getPost('is_embedded_form');
+        $redirect_url = $this->request->getPost('redirect_to');
+
+        if ($redirect_url) {
+            $redirect_url = clean_data($redirect_url);
+        }
+
+        $first_name = trim((string) $this->request->getPost('first_name'));
+        $last_name = trim((string) $this->request->getPost('last_name'));
+        $company_name = trim((string) $this->request->getPost('company_name'));
+        $address = trim((string) $this->request->getPost('address'));
+        $city = trim((string) $this->request->getPost('city'));
+        $state = trim((string) $this->request->getPost('state'));
+        $zip = trim((string) $this->request->getPost('zip'));
+        $phone = trim((string) $this->request->getPost('phone'));
+        $lead_source_id = (int) $this->request->getPost('lead_source_id');
+
+        validate_numeric_value($lead_source_id);
 
         //check if there reCaptcha is enabled
         //if reCaptcha is enabled, check the validation
-        $ReCAPTCHA = new ReCAPTCHA();
-        $ReCAPTCHA->validate_recaptcha();
+        if (!$is_embedded_form) {
+            $ReCAPTCHA = new ReCAPTCHA();
+            $ReCAPTCHA->validate_recaptcha();
+        }
 
         $now = get_current_utc_time();
+
+        $labels = $this->request->getPost('labels');
+        $labels = $labels ? $labels : "";
+        validate_list_of_numbers($labels);
+
+        $assigned_to = (int) $this->request->getPost('assigned_to');
+
+        $lead_source_owner_map = array(
+            2 => 254,
+            3 => 253,
+            4 => 251,
+            5 => 3827,
+            6 => 252
+        );
+
+        if (isset($lead_source_owner_map[$lead_source_id])) {
+            $assigned_to = $lead_source_owner_map[$lead_source_id];
+        }
+        $ticket_type_id = (int) $this->request->getPost('ticket_type_id');
+
+        $ticket_type_title = '';
+        if ($ticket_type_id) {
+            $ticket_type = $this->Ticket_types_model->get_one($ticket_type_id);
+            if ($ticket_type && $ticket_type->id) {
+                $ticket_type_title = (string) $ticket_type->title;
+            }
+        }
 
         $ticket_data = array(
             "title" => $this->request->getPost('title'),
             "created_at" => $now,
             "last_activity_at" => $now,
-            "ticket_type_id" => $this->request->getPost('ticket_type_id')
+            "ticket_type_id" => $ticket_type_id,
+            "labels" => $labels,
+            "assigned_to" => $assigned_to ? $assigned_to : 0
         );
+
+        $submitted_custom_fields = $this->collectSubmittedCustomFieldValues();
 
         //match with the existing client
         $email = $this->request->getPost('email');
@@ -67,7 +138,8 @@ class External_tickets extends App_Controller {
             $ticket_data["client_id"] = 0;
             $ticket_data["created_by"] = 0;
             $ticket_data["requested_by"] = 0;
-            $ticket_data["creator_name"] = $this->request->getPost('name') ? $this->request->getPost('name') : "";
+            $combined_name = trim($first_name . " " . $last_name);
+            $ticket_data["creator_name"] = $combined_name ? $combined_name : "";
         }
 
         $ticket_data = clean_data($ticket_data);
@@ -79,8 +151,104 @@ class External_tickets extends App_Controller {
             save_custom_fields("tickets", $ticket_id, 0, "client");
 
             //save ticket's comment
+            $description = (string) $this->request->getPost('description');
+
+            $form_data = array();
+
+            if ($ticket_type_title) {
+                $form_data['request_type'] = $ticket_type_title;
+            }
+
+            $form_data = $form_data + array(
+                'first_name' => $first_name,
+                'last_name' => $last_name,
+                'company_name' => $company_name,
+                'email' => $email,
+                'address' => $address,
+                'city' => $city,
+                'state' => $state,
+                'zip' => $zip,
+                'phone' => $phone
+            );
+
+            if ($lead_source_id) {
+                $lead_source_label = "";
+                $lead_source = $this->Lead_source_model->get_one($lead_source_id);
+                if ($lead_source && $lead_source->id) {
+                    $lead_source_label = $lead_source->title;
+                }
+
+                $form_data['lead_source'] = $lead_source_label ? $lead_source_label : $lead_source_id;
+            }
+
+            $form_data = $this->filterEmptyFormData($form_data);
+
+            $contact_labels = array(
+                'first_name' => app_lang('first_name'),
+                'last_name' => app_lang('last_name'),
+                'company_name' => app_lang('company_name'),
+                'email' => app_lang('email'),
+                'address' => app_lang('address'),
+                'city' => app_lang('city'),
+                'state' => app_lang('state'),
+                'zip' => app_lang('zip'),
+                'phone' => app_lang('phone'),
+                'lead_source' => app_lang('lead_source')
+            );
+
+            if ($ticket_type_title) {
+                $request_type_label = app_lang('request_type');
+                if ($request_type_label === 'request_type') {
+                    $request_type_label = 'Request Type';
+                }
+
+                $contact_labels = array('request_type' => $request_type_label) + $contact_labels;
+            }
+
+            $contact_lines = array();
+            foreach ($contact_labels as $key => $label) {
+                if (!isset($form_data[$key])) {
+                    continue;
+                }
+
+                $value = $form_data[$key];
+                $contact_lines[] = "<strong>" . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . ":</strong> " . nl2br(htmlspecialchars($value, ENT_QUOTES, 'UTF-8'));
+            }
+
+            $sections = array();
+            if (!empty($contact_lines)) {
+                $contact_heading = app_lang('contact_information');
+                if ($contact_heading === 'contact_information') {
+                    $contact_heading = 'Contact Information';
+                }
+
+                $contact_block = "<div><strong>" . htmlspecialchars($contact_heading, ENT_QUOTES, 'UTF-8') . "</strong></div><div>" . implode("</div><div>", $contact_lines) . "</div>";
+                $sections[] = $contact_block;
+            }
+
+            if (!empty($submitted_custom_fields)) {
+                $custom_lines = array();
+                foreach ($submitted_custom_fields as $field) {
+                    $custom_lines[] = "<strong>" . htmlspecialchars($field['label'], ENT_QUOTES, 'UTF-8') . ":</strong> " . nl2br(htmlspecialchars($field['value'], ENT_QUOTES, 'UTF-8'));
+                }
+
+                if (!empty($custom_lines)) {
+                    $custom_heading = app_lang('additional_information');
+                    if ($custom_heading === 'additional_information') {
+                        $custom_heading = 'Additional Information';
+                    }
+
+                    $custom_block = "<div><strong>" . htmlspecialchars($custom_heading, ENT_QUOTES, 'UTF-8') . "</strong></div><div>" . implode("</div><div>", $custom_lines) . "</div>";
+                    $sections[] = $custom_block;
+                }
+            }
+
+            if (!empty($sections)) {
+                $description = implode("<br /><br />", $sections) . "<br /><br />" . $description;
+            }
+
             $comment_data = array(
-                "description" => $this->request->getPost('description'),
+                "description" => $description,
                 "ticket_id" => $ticket_id,
                 "created_by" => $contact_info->id ? $contact_info->id : 0,
                 "created_at" => $now
@@ -94,11 +262,57 @@ class External_tickets extends App_Controller {
             $ticket_comment_id = $this->Ticket_comments_model->ci_save($comment_data);
 
             if ($ticket_id && $ticket_comment_id) {
+                $notification_payload = array();
+                if (!empty($form_data)) {
+                    $notification_payload['form_data'] = $form_data;
+                }
+
+                if (!empty($submitted_custom_fields)) {
+                    $custom_field_values = array();
+                    foreach ($submitted_custom_fields as $field) {
+                        $custom_field_values[] = array(
+                            'title' => $field['label'],
+                            'value' => $field['value']
+                        );
+                    }
+
+                    if (!empty($custom_field_values)) {
+                        $notification_payload['custom_field_values'] = $custom_field_values;
+                    }
+                }
+
+                if ($ticket_type_id || $ticket_type_title !== '') {
+                    $notification_payload['request_type'] = array(
+                        'id' => $ticket_type_id,
+                        'title' => $ticket_type_title
+                    );
+                }
+
                 add_auto_reply_to_ticket($ticket_id);
 
-                log_notification("ticket_created", array("ticket_id" => $ticket_id, "ticket_comment_id" => $ticket_comment_id, "exclude_ticket_creator" => true), $contact_info->id ? $contact_info->id : "0");
+                $notification_options = array(
+                    "ticket_id" => $ticket_id,
+                    "ticket_comment_id" => $ticket_comment_id,
+                    "exclude_ticket_creator" => true
+                );
 
-                echo json_encode(array("success" => true, 'message' => app_lang('ticket_submission_message')));
+                if (!empty($notification_payload)) {
+                    $notification_options['description'] = json_encode($notification_payload, JSON_UNESCAPED_UNICODE);
+                }
+
+                log_notification("ticket_created", $notification_options, $contact_info->id ? $contact_info->id : "0");
+
+                if ($redirect_url && !$this->request->isAJAX()) {
+                    return redirect()->to($redirect_url);
+                }
+
+                $response = array("success" => true, 'message' => app_lang('ticket_submission_message'));
+
+                if ($redirect_url) {
+                    $response['redirect_url'] = $redirect_url;
+                }
+
+                echo json_encode($response);
 
                 return true;
             }
@@ -116,8 +330,257 @@ class External_tickets extends App_Controller {
             $view_data['embedded'] = "Please save the settings first to see the code.";
         }
 
+        $view_data['ticket_types'] = $this->Ticket_types_model->get_all_where(array("deleted" => 0))->getResult();
+        $view_data['assignees'] = $this->Users_model->get_all_where(array("user_type" => "staff", "deleted" => 0, "status" => "active"))->getResult();
+        $view_data['labels'] = $this->Labels_model->get_details(array("context" => "ticket"))->getResult();
+        $view_data['custom_fields'] = $this->getEmbeddableTicketCustomFields();
 
         return $this->template->view('external_tickets/embedded_code_modal_form', $view_data);
+    }
+
+    function ticket_html_form_code_modal_form() {
+        $view_data['ticket_html_form_code'] = $this->_ticket_html_form_code();
+        $view_data['ticket_types'] = $this->Ticket_types_model->get_all_where(array("deleted" => 0))->getResult();
+        $view_data['assignees'] = $this->Users_model->get_all_where(array("user_type" => "staff", "deleted" => 0, "status" => "active"))->getResult();
+        $view_data['labels'] = $this->Labels_model->get_details(array("context" => "ticket"))->getResult();
+        $view_data['custom_fields'] = $this->getEmbeddableTicketCustomFields();
+
+        return $this->template->view('external_tickets/ticket_html_form_code_modal_form', $view_data);
+    }
+
+    function get_ticket_html_form_code() {
+        $ticket_type_id = (int) $this->request->getPost('ticket_type_id');
+        $assignee_id = (int) $this->request->getPost('assigned_to');
+
+        validate_numeric_value($ticket_type_id);
+        validate_numeric_value($assignee_id);
+        $labels_input = $this->request->getPost('labels');
+        $custom_fields_input = $this->request->getPost('custom_fields');
+
+        $label_ids = $this->sanitizeLabelIds($labels_input);
+        $custom_field_ids = $this->sanitizeIdList($custom_fields_input);
+
+        echo $this->_ticket_html_form_code($ticket_type_id, $assignee_id, $label_ids, $custom_field_ids);
+    }
+
+    private function _ticket_html_form_code($ticket_type_id = 0, $assignee_id = 0, $label_ids = "", array $custom_field_ids = array()) {
+        validate_numeric_value($ticket_type_id);
+        validate_numeric_value($assignee_id);
+
+        $view_data = array(
+            'selected_ticket_type_id' => $ticket_type_id,
+            'selected_assignee_id' => $assignee_id,
+            'selected_label_ids' => $label_ids,
+            'custom_fields' => $this->filterCustomFieldsForEmbed($this->getEmbeddableTicketCustomFields(), $custom_field_ids),
+            'ticket_types' => $this->Ticket_types_model->get_all_where(array("deleted" => 0))->getResult()
+        );
+
+        return view('external_tickets/ticket_html_form_code', $view_data);
+    }
+
+    private function sanitizeLabelIds($label_ids = "") {
+        if (!$label_ids) {
+            return "";
+        }
+
+        if (is_array($label_ids)) {
+            $ids = $label_ids;
+        } else {
+            $ids = preg_split('/[,-]/', $label_ids, -1, PREG_SPLIT_NO_EMPTY);
+        }
+        $clean = array();
+
+        foreach ($ids as $id) {
+            $id = trim($id);
+            if ($id === "") {
+                continue;
+            }
+            if (is_numeric($id)) {
+                $clean[] = (int) $id;
+            }
+        }
+
+        $clean = array_values(array_unique($clean));
+
+        return $clean ? implode(',', $clean) : "";
+    }
+
+    private function sanitizeIdList($value): array {
+        if (!$value) {
+            return array();
+        }
+
+        if (is_array($value)) {
+            $raw_ids = $value;
+        } else {
+            $raw_ids = preg_split('/[,]/', (string) $value, -1, PREG_SPLIT_NO_EMPTY);
+        }
+
+        $clean = array();
+
+        foreach ($raw_ids as $id) {
+            if (is_numeric($id)) {
+                $clean[] = (int) $id;
+            }
+        }
+
+        return array_values(array_unique($clean));
+    }
+
+    private function getEmbeddableTicketCustomFields(): array {
+        $fields = $this->Custom_fields_model->get_combined_details("tickets", 0, 0, "client")->getResult();
+
+        if (!is_array($fields)) {
+            return array();
+        }
+
+        $unique = array();
+
+        foreach ($fields as $field) {
+            if (!isset($field->id)) {
+                continue;
+            }
+
+            $unique[(int) $field->id] = $field;
+        }
+
+        return array_values($unique);
+    }
+
+    private function filterCustomFieldsForEmbed($fields, array $selected_ids = array()) {
+        if (!is_array($fields)) {
+            return array();
+        }
+
+        $filtered = array();
+        $has_selection = !empty($selected_ids);
+        $selected_lookup = array();
+
+        if ($has_selection) {
+            foreach ($selected_ids as $id) {
+                $selected_lookup[(int) $id] = true;
+            }
+        }
+
+        foreach ($fields as $field) {
+            if (!isset($field->id)) {
+                continue;
+            }
+
+            $field_id = (int) $field->id;
+            $is_selected = $has_selection && isset($selected_lookup[$field_id]);
+            $allow_in_embed = !isset($field->show_in_embedded_form) || (int) $field->show_in_embedded_form === 1;
+
+            if ($has_selection) {
+                if (!$is_selected) {
+                    continue;
+                }
+            } elseif (!$allow_in_embed) {
+                continue;
+            }
+
+            $filtered[] = $field;
+        }
+
+        return $filtered;
+    }
+
+    private function collectSubmittedCustomFieldValues(): array {
+        $fields = $this->getEmbeddableTicketCustomFields();
+
+        if (!is_array($fields) || empty($fields)) {
+            return array();
+        }
+
+        $values = array();
+
+        foreach ($fields as $field) {
+            if (!isset($field->id)) {
+                continue;
+            }
+
+            $field_name = 'custom_field_' . $field->id;
+            $raw_value = $this->request->getPost($field_name);
+
+            if ($raw_value === null) {
+                continue;
+            }
+
+            $normalized = $this->normalizeCustomFieldValue($raw_value);
+
+            if ($normalized === '') {
+                continue;
+            }
+
+            $label = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+
+            if ($label === '') {
+                $label = 'Field ' . $field->id;
+            }
+
+            $values[] = array(
+                'label' => $label,
+                'value' => $normalized
+            );
+        }
+
+        return $values;
+    }
+
+    private function normalizeCustomFieldValue($value): string {
+        if (is_array($value)) {
+            $pieces = array();
+            foreach ($value as $item) {
+                $normalized = $this->normalizeCustomFieldValue($item);
+                if ($normalized !== '') {
+                    $pieces[] = $normalized;
+                }
+            }
+
+            return $pieces ? implode(', ', $pieces) : '';
+        }
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? app_lang('yes') : app_lang('no');
+        }
+
+        if (is_scalar($value)) {
+            return trim((string) $value);
+        }
+
+        return '';
+    }
+
+    private function filterEmptyFormData(array $form_data): array {
+        $filtered = array();
+
+        foreach ($form_data as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_bool($value)) {
+                $filtered[$key] = $value ? app_lang('yes') : app_lang('no');
+                continue;
+            }
+
+            if (is_scalar($value)) {
+                $string_value = (string) $value;
+                $trimmed = trim($string_value);
+
+                if ($trimmed === '' && $string_value !== '0') {
+                    continue;
+                }
+
+                $filtered[$key] = $trimmed;
+            }
+        }
+
+        return $filtered;
     }
 }
 

--- a/app/Controllers/External_tickets.php
+++ b/app/Controllers/External_tickets.php
@@ -102,7 +102,9 @@ class External_tickets extends App_Controller {
             6 => 252
         );
 
-        if ($should_auto_assign_owner && isset($lead_source_owner_map[$lead_source_id])) {
+        $has_manual_assignee = $assigned_to ? true : false;
+
+        if ($should_auto_assign_owner && !$has_manual_assignee && isset($lead_source_owner_map[$lead_source_id])) {
             $assigned_to = $lead_source_owner_map[$lead_source_id];
         }
         $ticket_type_id = (int) $this->request->getPost('ticket_type_id');

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -482,6 +482,7 @@ $lang["ticket_status"] = "Service Request Stage";
 $lang["add_ticket_type"] = "Add service request type";
 $lang["ticket_type"] = "Service Request type";
 $lang["ticket_types"] = "Service Request types";
+$lang["request_type"] = "Service Request type";
 $lang["edit_ticket_type"] = "Edit service request type";
 $lang["delete_ticket_type"] = "Delete service request type";
 
@@ -907,6 +908,8 @@ $lang["clear"] = "Clear";
 $lang["expired"] = "Expired";
 $lang["enable_attachment"] = "Enable attachment";
 $lang["custom_fields"] = "Custom fields";
+$lang["additional_information"] = "Additional Information";
+$lang["no_additional_information_provided"] = "No additional information provided.";
 $lang["edit_field"] = "Edit field";
 $lang["delete_field"] = "Delete field";
 $lang["client_info"] = "Opportunity info";
@@ -1994,6 +1997,7 @@ $lang["field_type_time"] = "Time";
 $lang["client_can_assign_tasks"] = "Opportunity can assign objectives?";
 $lang["can_create_lead_from_public_form"] = "Can create lead from public form";
 $lang["lead_html_form_code"] = "Lead creation HTML form code";
+$lang["ticket_html_form_code"] = "Ticket submission HTML form code";
 
 $lang["enable_comments_on_estimates"] = "Enable comments on quotes";
 $lang["show_most_recent_estimate_comments_at_the_top"] = "Show most recent quote comments at the top";

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -482,6 +482,7 @@ $lang["ticket_status"] = "Ticket Stage";
 $lang["add_ticket_type"] = "Add ticket type";
 $lang["ticket_type"] = "Ticket type";
 $lang["ticket_types"] = "Ticket types";
+$lang["request_type"] = "Request Type";
 $lang["edit_ticket_type"] = "Edit ticket type";
 $lang["delete_ticket_type"] = "Delete ticket type";
 
@@ -911,6 +912,8 @@ $lang["clear"] = "Clear";
 $lang["expired"] = "Expired";
 $lang["enable_attachment"] = "Enable attachment";
 $lang["custom_fields"] = "Custom fields";
+$lang["additional_information"] = "Additional Information";
+$lang["no_additional_information_provided"] = "No additional information provided.";
 $lang["edit_field"] = "Edit field";
 $lang["delete_field"] = "Delete field";
 $lang["client_info"] = "Client info";
@@ -1990,6 +1993,7 @@ $lang["field_type_time"] = "Time";
 $lang["client_can_assign_tasks"] = "Client can assign tasks?";
 $lang["can_create_lead_from_public_form"] = "Can create lead from public form";
 $lang["lead_html_form_code"] = "Lead creation HTML form code";
+$lang["ticket_html_form_code"] = "Ticket submission HTML form code";
 
 $lang["enable_comments_on_estimates"] = "Enable comments on estimates";
 $lang["show_most_recent_estimate_comments_at_the_top"] = "Show most recent estimate comments at the top";

--- a/app/Views/external_tickets/embedded_code_modal_form.php
+++ b/app/Views/external_tickets/embedded_code_modal_form.php
@@ -3,14 +3,76 @@
         <div class="container-fluid">
             <div class="form-group">
                 <div class="row">
+                    <label for="embed_ticket_type_id" class="col-md-3"><?php echo app_lang('ticket_type'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $ticket_type_dropdown = array('' => "- " . app_lang('ticket_type') . " -");
+                        if (!empty($ticket_types)) {
+                            foreach ($ticket_types as $type) {
+                                $ticket_type_dropdown[$type->id] = $type->title;
+                            }
+                        }
+                        echo form_dropdown('embed_ticket_type_id', $ticket_type_dropdown, '', "class='select2' id='embed_ticket_type_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_assigned_to" class="col-md-3"><?php echo app_lang('assign_to'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $assignee_dropdown = array('' => "- " . app_lang('assign_to') . " -");
+                        if (!empty($assignees)) {
+                            foreach ($assignees as $member) {
+                                $full_name = trim($member->first_name . ' ' . $member->last_name);
+                                $assignee_dropdown[$member->id] = $full_name ? $full_name : $member->first_name;
+                            }
+                        }
+                        echo form_dropdown('embed_assigned_to', $assignee_dropdown, '', "class='select2' id='embed_assigned_to'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_ticket_labels" class="col-md-3"><?php echo app_lang('labels'); ?></label>
+                    <div class="col-md-9">
+                        <select id="embed_ticket_labels" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($labels)) {
+                                foreach ($labels as $label) {
+                                    ?><option value="<?php echo htmlspecialchars($label->id); ?>"><?php echo htmlspecialchars($label->title); ?></option><?php
+                                }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="embed_ticket_custom_fields" class="col-md-3"><?php echo app_lang('custom_fields'); ?></label>
+                    <div class="col-md-9">
+                        <select id="embed_ticket_custom_fields" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($custom_fields)) {
+                                foreach ($custom_fields as $field) {
+                                    $field_title = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+                                    ?><option value="<?php echo htmlspecialchars($field->id); ?>"><?php echo htmlspecialchars($field_title); ?></option><?php
+                                }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
                     <div class="col-md-12">
                         <?php
                         echo form_textarea(array(
-                            "id" => "embedded-code",
-                            "name" => "embedded-code",
-                            "value" => $embedded,
-                            "class" => "form-control",
-                            "data-rich-text-editor" => false
+                            'id' => 'embedded-code',
+                            'name' => 'embedded-code',
+                            'value' => $embedded,
+                            'class' => 'form-control',
+                            'data-rich-text-editor' => false
                         ));
                         ?>
                     </div>
@@ -26,8 +88,62 @@
 
 <script type="text/javascript">
     $(document).ready(function () {
+        var $ticketType = $("#embed_ticket_type_id");
+        var $assignee = $("#embed_assigned_to");
+        var $labels = $("#embed_ticket_labels");
+        var $customFields = $("#embed_ticket_custom_fields");
+        var $embedTextarea = $("#embedded-code");
+
+        $(".select2").select2();
+
+        function buildIframeSrc() {
+            var ticketTypeId = $ticketType.val() || "";
+            var assigneeId = $assignee.val() || "";
+            var labelIds = $labels.val() || [];
+            var customFieldIds = $customFields.val() || [];
+
+            var segments = [];
+            if (ticketTypeId || assigneeId || labelIds.length) {
+                segments[0] = ticketTypeId ? ticketTypeId : 0;
+                segments[1] = assigneeId ? assigneeId : 0;
+                if (labelIds.length) {
+                    segments[2] = encodeURIComponent(labelIds.join(','));
+                }
+            }
+
+            var cleanedSegments = [];
+            for (var i = 0; i < segments.length; i++) {
+                if (typeof segments[i] !== "undefined") {
+                    cleanedSegments.push(segments[i]);
+                }
+            }
+
+            var iframeSrc = "<?php echo get_uri('external_tickets'); ?>";
+            if (cleanedSegments.length) {
+                iframeSrc = "<?php echo get_uri('external_tickets/index'); ?>" + "/" + cleanedSegments.join('/');
+            }
+
+            if (customFieldIds.length) {
+                var query = "custom_fields=" + encodeURIComponent(customFieldIds.join(','));
+                iframeSrc += (iframeSrc.indexOf('?') === -1 ? '?' : '&') + query;
+            }
+
+            return "<iframe width='768' height='840' src='" + iframeSrc + "' frameborder='0'></iframe>";
+        }
+
+        function updateEmbedCode() {
+            $embedTextarea.val(buildIframeSrc());
+        }
+
+        $ticketType.on("change", updateEmbedCode);
+        $assignee.on("change", updateEmbedCode);
+        $labels.on("change", updateEmbedCode);
+        $customFields.on("change", updateEmbedCode);
+
+        updateEmbedCode();
+
         $("#copy-button").click(function () {
-            var copyTextarea = document.querySelector('#embedded-code');
+            var copyTextarea = $embedTextarea[0];
             copyTextarea.focus();
             copyTextarea.select();
             document.execCommand('copy');

--- a/app/Views/external_tickets/index.php
+++ b/app/Views/external_tickets/index.php
@@ -90,20 +90,37 @@ table.dataTable tbody td:first-child {
 <div id="page-content" class="page-wrapper clearfix">
     <div id="external-ticket-form-container">
 
-        <?php echo form_open(get_uri("external_tickets/save"), array("id" => "ticket-form", "class" => "general-form", "role" => "form")); ?>
+        <?php
+        $phone_minlength_message = app_lang('phone_minlength_error');
+        if ($phone_minlength_message === 'phone_minlength_error') {
+            $phone_minlength_message = "Phone number must be at least 10 digits.";
+        }
+
+        echo form_open(get_uri("external_tickets/save"), array("id" => "ticket-form", "class" => "general-form", "role" => "form"));
+        ?>
         <div id="new-ticket-dropzone" class="card p15 no-border clearfix post-dropzone client-info-section" style="max-width: 100%; margin: auto;">
 
 
+            <input type="hidden" name="is_embedded_form" value="1" />
+            <input type="hidden" name="redirect_to" value="https://www.avenirenergy.ca/avenir-energy-thank-you" />
+            <?php
+            $default_assignee_id = !empty($selected_assignee_id) ? htmlspecialchars($selected_assignee_id) : "";
+            ?>
+            <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" />
+            <?php if (!empty($selected_label_ids)) { ?>
+                <input type="hidden" name="labels" value="<?php echo htmlspecialchars($selected_label_ids); ?>" />
+            <?php } ?>
+
             <div class="form-group">
-                <label for="title"><?php echo app_lang('title'); ?></label>
+                <label for="first_name"><?php echo app_lang('first_name'); ?>*</label>
                 <div>
                     <?php
                     echo form_input(array(
-                        "id" => "title",
-                        "name" => "title",
+                        "id" => "first_name",
+                        "name" => "first_name",
                         "value" => "",
                         "class" => "form-control",
-                        "placeholder" => app_lang('title'),
+                        "placeholder" => app_lang('first_name'),
                         "autofocus" => true,
                         "data-rule-required" => true,
                         "data-msg-required" => app_lang("field_required"),
@@ -113,22 +130,45 @@ table.dataTable tbody td:first-child {
             </div>
 
             <div class="form-group">
-                <label for="ticket_type_id"><?php echo app_lang('ticket_type'); ?></label>
+                <label for="last_name"><?php echo app_lang('last_name'); ?>*</label>
                 <div>
                     <?php
-                    echo form_dropdown("ticket_type_id", $ticket_types_dropdown, "", "class='select2'");
+                    echo form_input(array(
+                        "id" => "last_name",
+                        "name" => "last_name",
+                        "value" => "",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('last_name'),
+                        "data-rule-required" => true,
+                        "data-msg-required" => app_lang("field_required"),
+                    ));
                     ?>
                 </div>
             </div>
-    <div class="form-group">
-                <label for="email"><?php echo app_lang('your_email'); ?></label>
+
+            <div class="form-group">
+                <label for="company_name"><?php echo app_lang('company_name'); ?></label>
+                <div>
+                    <?php
+                    echo form_input(array(
+                        "id" => "company_name",
+                        "name" => "company_name",
+                        "value" => "",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('company_name')
+                    ));
+                    ?>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="email"><?php echo app_lang('email'); ?>*</label>
                 <div>
                     <?php
                     echo form_input(array(
                         "id" => "email",
                         "name" => "email",
                         "class" => "form-control p10",
-                        "autofocus" => true,
                         "placeholder" => app_lang('email'),
                         "data-rule-email" => true,
                         "data-msg-email" => app_lang("enter_valid_email"),
@@ -140,22 +180,142 @@ table.dataTable tbody td:first-child {
             </div>
 
             <div class="form-group">
-                <label for="name"><?php echo app_lang('your_name'); ?></label>
+                <label for="address"><?php echo app_lang('address'); ?>*</label>
                 <div>
                     <?php
                     echo form_input(array(
-                        "id" => "name",
-                        "name" => "name",
-                        "value" => "",
+                        "id" => "address",
+                        "name" => "address",
                         "class" => "form-control",
-                        "placeholder" => app_lang('name'),
+                        "placeholder" => app_lang('address'),
+                        "autocomplete" => "off",
+                        "data-autofill" => "new-address",
+                        "aria-autocomplete" => "list",
+                        "data-rule-required" => true,
+                        "data-msg-required" => app_lang("field_required"),
                     ));
                     ?>
                 </div>
             </div>
-      
 
-            <?php echo view("custom_fields/form/prepare_context_fields", array("custom_fields" => $custom_fields, "label_column" => "", "field_column" => "")); ?> 
+            <div class="form-group">
+                <label for="city"><?php echo app_lang('city'); ?>*</label>
+                <div>
+                    <?php
+                    echo form_input(array(
+                        "id" => "city",
+                        "name" => "city",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('city'),
+                        "data-rule-required" => true,
+                        "data-msg-required" => app_lang("field_required"),
+                    ));
+                    ?>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="state"><?php echo app_lang('state'); ?>*</label>
+                <div>
+                    <select id="state" name="state" class="form-control select2" data-rule-required="true" data-msg-required="<?php echo app_lang('field_required'); ?>">
+                        <option value="">- Select Province -</option>
+                        <option value="New Brunswick">New Brunswick</option>
+                        <option value="Nova Scotia">Nova Scotia</option>
+                        <option value="Prince Edward Island">Prince Edward Island</option>
+                        <option value="Quebec">Quebec</option>
+                        <option value="Ontario">Ontario</option>
+                        <option value="Manitoba">Manitoba</option>
+                        <option value="Northwest Territories">Northwest Territories</option>
+                        <option value="British Columbia">British Columbia</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="zip"><?php echo app_lang('zip'); ?>*</label>
+                <div>
+                    <?php
+                    echo form_input(array(
+                        "id" => "zip",
+                        "name" => "zip",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('zip'),
+                        "data-rule-required" => true,
+                        "data-msg-required" => app_lang("field_required"),
+                    ));
+                    ?>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="lead_source_id"><?php echo app_lang('lead_source'); ?>*</label>
+                <div>
+                    <select
+                        name="lead_source_id"
+                        id="lead_source_id"
+                        class="form-control select2"
+                        data-rule-required="true"
+                        data-msg-required="<?php echo app_lang("field_required"); ?>"
+                    >
+                        <option value="">- Select -</option>
+                        <option value="1">CA_Eastern ROC</option>
+                        <option value="2">CA_Pacific</option>
+                        <option value="3">CA_Prairies</option>
+                        <option value="4">CA_Atlantic</option>
+                        <option value="5">CA_Quebec</option>
+                        <option value="6">CA_Ontario</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="phone"><?php echo app_lang('phone'); ?>*</label>
+                <div>
+                    <?php
+                    echo form_input(array(
+                        "id" => "phone",
+                        "name" => "phone",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('phone'),
+                        "data-rule-required" => true,
+                        "data-msg-required" => app_lang("field_required"),
+                        "data-rule-minlength" => 10,
+                        "data-msg-minlength" => $phone_minlength_message,
+                    ));
+                    ?>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="title"><?php echo app_lang('title'); ?></label>
+                <div>
+                    <?php
+                    echo form_input(array(
+                        "id" => "title",
+                        "name" => "title",
+                        "value" => "",
+                        "class" => "form-control",
+                        "placeholder" => app_lang('title'),
+                    ));
+                    ?>
+                </div>
+            </div>
+
+            <?php if (!empty($selected_ticket_type_id)) { ?>
+                <input type="hidden" name="ticket_type_id" value="<?php echo htmlspecialchars($selected_ticket_type_id); ?>" />
+            <?php } else { ?>
+                <div class="form-group">
+                    <label for="ticket_type_id"><?php echo app_lang('ticket_type'); ?></label>
+                    <div>
+                        <?php
+                        echo form_dropdown("ticket_type_id", $ticket_types_dropdown, "", "class='select2'");
+                        ?>
+                    </div>
+                </div>
+            <?php } ?>
+
+
+            <?php echo view("custom_fields/form/prepare_context_fields", array("custom_fields" => $custom_fields, "label_column" => "", "field_column" => "")); ?>
 
               <div class="form-group">
                 <label for="description"><?php echo app_lang('description'); ?></label>
@@ -207,6 +367,12 @@ table.dataTable tbody td:first-child {
             },
             onSuccess: function (result) {
                 appLoader.hide();
+
+                if (result.redirect_url) {
+                    window.top.location.href = result.redirect_url;
+                    return;
+                }
+
                 $("#external-ticket-form-container").html("");
                 appAlert.success(result.message, {container: "#external-ticket-form-container", animate: false});
                 $('.scrollable-page').scrollTop(0); //scroll to top
@@ -214,9 +380,121 @@ table.dataTable tbody td:first-child {
         });
 
         setTimeout(function () {
-            $("#title").focus();
+            $("#first_name").focus();
         }, 200);
 
         $("#ticket-form .select2").select2();
+
+        var addressInput = $("#address");
+        addressInput.attr('autocomplete', 'new-address');
+        addressInput.on('focus', function () {
+            $(this).attr('autocomplete', 'new-address');
+        });
+
+        var ownerMap = {
+            "2": "254",
+            "3": "253",
+            "4": "251",
+            "5": "3827",
+            "6": "252"
+        };
+
+        var $assignedTo = $("#assigned_to");
+        var defaultAssignee = "";
+        if ($assignedTo.length) {
+            var storedDefault = $assignedTo.attr("data-default-value");
+            defaultAssignee = typeof storedDefault !== "undefined" ? storedDefault : ($assignedTo.val() || "");
+        }
+
+        function updateAssignedOwner(leadSourceId) {
+            if (!$assignedTo.length) {
+                return;
+            }
+
+            var leadSourceKey = leadSourceId ? String(leadSourceId) : "";
+            var mappedOwner = ownerMap.hasOwnProperty(leadSourceKey) ? ownerMap[leadSourceKey] : "";
+            if (mappedOwner) {
+                $assignedTo.val(mappedOwner);
+            } else {
+                $assignedTo.val(defaultAssignee);
+            }
+        }
+
+        $("#state, #city").on("change keyup", updateLeadSource);
+        updateLeadSource();
+
+        function updateLeadSource() {
+            var provinceVal = $("#state").val();
+
+            if (!provinceVal) {
+                $("#lead_source_id").val("").trigger("change");
+                updateAssignedOwner("");
+                return;
+            }
+
+            var sourceMap = {
+                "New Brunswick": 4,
+                "Nova Scotia": 4,
+                "Prince Edward Island": 4,
+                "Quebec": 5,
+                "Ontario": 6,
+                "Manitoba": 3,
+                "Northwest Territories": 3,
+                "British Columbia": 3
+            };
+
+            if (provinceVal === "British Columbia") {
+                var bcCitiesKeywords = [
+                    "vancouver", "burnaby", "richmond", "surrey", "delta", "new westminster",
+                    "langley", "white rock", "maple ridge", "pitt meadows", "coquitlam",
+                    "port coquitlam", "port moody", "north vancouver", "west vancouver",
+                    "belcarra", "anmore", "bowen island", "lions bay",
+                    "abbotsford", "chilliwack", "mission", "kent", "agassiz",
+                    "harrison hot springs", "hope",
+                    "sechelt", "gibsons",
+                    "victoria", "saanich", "oak bay", "esquimalt", "view royal", "colwood",
+                    "langford", "metchosin", "highlands", "sooke", "central saanich", "north saanich",
+                    "sidney", "duncan", "north cowichan", "lake cowichan", "ladysmith", "nanaimo",
+                    "lantzville", "parksville", "qualicum beach", "port alberni", "tofino",
+                    "ucluelet", "courtenay", "comox", "cumberland", "campbell river", "gold river",
+                    "tahsis", "zeballos", "port hardy", "port mcneill", "port alice", "alert bay"
+                ];
+
+                var cityVal = $("#city").val().trim().toLowerCase();
+                var matchedKeyword = bcCitiesKeywords.some(function (keyword) {
+                    return cityVal.indexOf(keyword) !== -1;
+                });
+
+                if (matchedKeyword) {
+                    $("#lead_source_id").val("2").trigger("change");
+                    updateAssignedOwner("2");
+                    return;
+                }
+            }
+
+            var mappedSource = sourceMap[provinceVal] || "";
+            var mappedSourceKey = mappedSource ? String(mappedSource) : "";
+            $("#lead_source_id").val(mappedSourceKey).trigger("change");
+            updateAssignedOwner(mappedSourceKey);
+        }
+
+        $("#lead_source_id").on("change", function () {
+            updateAssignedOwner($(this).val());
+        });
+
+        updateAssignedOwner($("#lead_source_id").val());
     });
 </script>
+
+<?php $googleMapsApiKey = get_setting('google_maps_api_key'); ?>
+<?php if ($googleMapsApiKey) { ?>
+    <script src="<?php echo base_url('assets/js/google_address_autocomplete.js'); ?>"></script>
+    <script>
+        function googleMapsReady() {
+            if (window.initAddressAutocomplete) {
+                window.initAddressAutocomplete(document);
+            }
+        }
+    </script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=<?php echo $googleMapsApiKey; ?>&libraries=places&v=beta&callback=googleMapsReady&loading=async"></script>
+<?php } ?>

--- a/app/Views/external_tickets/index.php
+++ b/app/Views/external_tickets/index.php
@@ -106,7 +106,8 @@ table.dataTable tbody td:first-child {
             <?php
             $default_assignee_id = !empty($selected_assignee_id) ? htmlspecialchars($selected_assignee_id) : "";
             ?>
-            <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" />
+            <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" data-owner-auto="1" />
+            <input type="hidden" name="auto_assign_owner" id="auto_assign_owner" value="1" />
             <?php if (!empty($selected_label_ids)) { ?>
                 <input type="hidden" name="labels" value="<?php echo htmlspecialchars($selected_label_ids); ?>" />
             <?php } ?>
@@ -400,14 +401,32 @@ table.dataTable tbody td:first-child {
         };
 
         var $assignedTo = $("#assigned_to");
+        var $autoAssign = $("#auto_assign_owner");
         var defaultAssignee = "";
         if ($assignedTo.length) {
             var storedDefault = $assignedTo.attr("data-default-value");
             defaultAssignee = typeof storedDefault !== "undefined" ? storedDefault : ($assignedTo.val() || "");
         }
 
+        var shouldAutoAssign = $assignedTo.length > 0;
+
+        if ($assignedTo.length) {
+            var ownerAutoAttr = $assignedTo.attr("data-owner-auto");
+            if (typeof ownerAutoAttr !== "undefined" && ownerAutoAttr === "0") {
+                shouldAutoAssign = false;
+            }
+        }
+
+        if ($autoAssign.length) {
+            if ($autoAssign.val() === "0") {
+                shouldAutoAssign = false;
+            }
+
+            $autoAssign.val(shouldAutoAssign ? "1" : "0");
+        }
+
         function updateAssignedOwner(leadSourceId) {
-            if (!$assignedTo.length) {
+            if (!$assignedTo.length || !shouldAutoAssign) {
                 return;
             }
 

--- a/app/Views/external_tickets/index.php
+++ b/app/Views/external_tickets/index.php
@@ -403,12 +403,16 @@ table.dataTable tbody td:first-child {
         var $assignedTo = $("#assigned_to");
         var $autoAssign = $("#auto_assign_owner");
         var defaultAssignee = "";
+        var hasDefaultAssignee = false;
         if ($assignedTo.length) {
             var storedDefault = $assignedTo.attr("data-default-value");
             defaultAssignee = typeof storedDefault !== "undefined" ? storedDefault : ($assignedTo.val() || "");
+            if (typeof defaultAssignee !== "undefined" && defaultAssignee !== null && $.trim(defaultAssignee) !== "") {
+                hasDefaultAssignee = true;
+            }
         }
 
-        var shouldAutoAssign = $assignedTo.length > 0;
+        var shouldAutoAssign = $assignedTo.length > 0 && !hasDefaultAssignee;
 
         if ($assignedTo.length) {
             var ownerAutoAttr = $assignedTo.attr("data-owner-auto");

--- a/app/Views/external_tickets/ticket_html_form_code.php
+++ b/app/Views/external_tickets/ticket_html_form_code.php
@@ -1,0 +1,224 @@
+<form action="<?php echo get_uri("external_tickets/save"); ?>" role="form" method="post" accept-charset="utf-8" id="external-ticket-form">
+
+    <input type="hidden" name="is_embedded_form" value="1" />
+    <input type="hidden" name="redirect_to" value="https://www.avenirenergy.ca/avenir-energy-thank-you" />
+
+    <?php
+    $default_assignee_id = !empty($selected_assignee_id) ? htmlspecialchars($selected_assignee_id) : "";
+    ?>
+    <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" />
+
+    <?php if (!empty($selected_label_ids)) { ?>
+        <input type="hidden" name="labels" value="<?php echo htmlspecialchars($selected_label_ids); ?>" />
+    <?php } ?>
+
+    <input type="text" name="first_name" id="first_name" placeholder="<?php echo app_lang('first_name'); ?>" required="required" />
+
+    <input type="text" name="last_name" id="last_name" placeholder="<?php echo app_lang('last_name'); ?>" required="required" />
+
+    <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" />
+
+    <input type="email" name="email" id="email" placeholder="<?php echo app_lang('email'); ?>" autocomplete="off" required="required" />
+
+    <input type="text" name="address" id="address" placeholder="<?php echo app_lang('address'); ?>" autocomplete="off" required="required" />
+
+    <input type="text" name="city" id="city" placeholder="<?php echo app_lang('city'); ?>" required="required" />
+
+    <select name="state" id="state" required="required">
+        <option value="">- Select Province -</option>
+        <option value="New Brunswick">New Brunswick</option>
+        <option value="Nova Scotia">Nova Scotia</option>
+        <option value="Prince Edward Island">Prince Edward Island</option>
+        <option value="Quebec">Quebec</option>
+        <option value="Ontario">Ontario</option>
+        <option value="Manitoba">Manitoba</option>
+        <option value="Northwest Territories">Northwest Territories</option>
+        <option value="British Columbia">British Columbia</option>
+    </select>
+
+    <input type="text" name="zip" id="zip" placeholder="<?php echo app_lang('zip'); ?>" required="required" />
+
+    <select name="lead_source_id" id="lead_source_id" required="required">
+        <option value="">- Select -</option>
+        <option value="1">CA_Eastern ROC</option>
+        <option value="2">CA_Pacific</option>
+        <option value="3">CA_Prairies</option>
+        <option value="4">CA_Atlantic</option>
+        <option value="5">CA_Quebec</option>
+        <option value="6">CA_Ontario</option>
+    </select>
+
+    <input type="tel" name="phone" id="phone" placeholder="<?php echo app_lang('phone'); ?>" minlength="10" required="required" />
+
+    <input type="text" name="title" id="title" placeholder="<?php echo app_lang('title'); ?>" />
+
+    <?php if (!empty($selected_ticket_type_id)) { ?>
+        <input type="hidden" name="ticket_type_id" value="<?php echo htmlspecialchars($selected_ticket_type_id); ?>" />
+    <?php } else { ?>
+        <select name="ticket_type_id" id="ticket_type_id">
+            <option value=""><?php echo "- " . app_lang('ticket_type') . " -"; ?></option>
+            <?php if (!empty($ticket_types)) { foreach ($ticket_types as $type) { ?>
+                <option value="<?php echo htmlspecialchars($type->id); ?>"><?php echo htmlspecialchars($type->title); ?></option>
+            <?php }} ?>
+        </select>
+    <?php } ?>
+
+    <?php if (!empty($custom_fields)) {
+        foreach ($custom_fields as $field) {
+            $field_id = isset($field->id) ? (int) $field->id : 0;
+            if (!$field_id) {
+                continue;
+            }
+
+            $field_title = isset($field->title_language_key) && $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+            $placeholder_language_key = isset($field->placeholder_language_key) ? $field->placeholder_language_key : "";
+            $placeholder_value = isset($field->placeholder) ? $field->placeholder : "";
+            $placeholder = $placeholder_language_key ? app_lang($placeholder_language_key) : ($placeholder_value ? $placeholder_value : $field_title);
+            $field_type = isset($field->field_type) ? $field->field_type : "";
+            $is_required = !empty($field->required);
+
+            $field_name = "custom_field_" . $field_id;
+            $required_attribute = $is_required ? ' required="required"' : '';
+
+            if ($field_type === "select") {
+                $options = array();
+                if (!empty($field->options)) {
+                    $raw_options = explode(",", $field->options);
+                    foreach ($raw_options as $option) {
+                        $trimmed = trim($option);
+                        if ($trimmed !== "") {
+                            $options[] = $trimmed;
+                        }
+                    }
+                }
+
+                ?>
+                <select name="<?php echo htmlspecialchars($field_name); ?>" id="<?php echo htmlspecialchars($field_name); ?>"<?php echo $required_attribute; ?>>
+                    <option value=""><?php echo htmlspecialchars($placeholder); ?></option>
+                    <?php foreach ($options as $option) { ?>
+                        <option value="<?php echo htmlspecialchars($option); ?>"><?php echo htmlspecialchars($option); ?></option>
+                    <?php } ?>
+                </select>
+                <?php
+                continue;
+            }
+
+            ?>
+            <input type="text" name="<?php echo htmlspecialchars($field_name); ?>" id="<?php echo htmlspecialchars($field_name); ?>" placeholder="<?php echo htmlspecialchars($placeholder); ?>"<?php echo $required_attribute; ?> />
+        <?php }
+    } ?>
+
+    <textarea name="description" id="description" placeholder="<?php echo app_lang('description'); ?>" required="required"></textarea>
+
+    <button type="submit"><?php echo app_lang('submit'); ?></button>
+
+</form>
+
+<script type="text/javascript">
+(function () {
+    var stateField = document.getElementById('state');
+    var cityField = document.getElementById('city');
+    var leadSourceField = document.getElementById('lead_source_id');
+    var assignedField = document.getElementById('assigned_to');
+
+    var defaultAssignee = assignedField ? (assignedField.getAttribute('data-default-value') || assignedField.value || '') : '';
+
+    var ownerMap = {
+        '2': '254',
+        '3': '253',
+        '4': '251',
+        '5': '3827',
+        '6': '252'
+    };
+
+    var sourceMap = {
+        'New Brunswick': '4',
+        'Nova Scotia': '4',
+        'Prince Edward Island': '4',
+        'Quebec': '5',
+        'Ontario': '6',
+        'Manitoba': '3',
+        'Northwest Territories': '3',
+        'British Columbia': '3'
+    };
+
+    var bcCitiesKeywords = [
+        'vancouver', 'burnaby', 'richmond', 'surrey', 'delta', 'new westminster',
+        'langley', 'white rock', 'maple ridge', 'pitt meadows', 'coquitlam',
+        'port coquitlam', 'port moody', 'north vancouver', 'west vancouver',
+        'belcarra', 'anmore', 'bowen island', 'lions bay',
+        'abbotsford', 'chilliwack', 'mission', 'kent', 'agassiz',
+        'harrison hot springs', 'hope',
+        'sechelt', 'gibsons',
+        'victoria', 'saanich', 'oak bay', 'esquimalt', 'view royal', 'colwood',
+        'langford', 'metchosin', 'highlands', 'sooke', 'central saanich', 'north saanich',
+        'sidney', 'duncan', 'north cowichan', 'lake cowichan', 'ladysmith', 'nanaimo',
+        'lantzville', 'parksville', 'qualicum beach', 'port alberni', 'tofino',
+        'ucluelet', 'courtenay', 'comox', 'cumberland', 'campbell river', 'gold river',
+        'tahsis', 'zeballos', 'port hardy', 'port mcneill', 'port alice', 'alert bay'
+    ];
+
+    function applyOwner(leadSourceId) {
+        if (!assignedField) {
+            return;
+        }
+
+        var leadSourceKey = leadSourceId ? String(leadSourceId) : '';
+
+        if (ownerMap.hasOwnProperty(leadSourceKey) && ownerMap[leadSourceKey]) {
+            assignedField.value = ownerMap[leadSourceKey];
+        } else {
+            assignedField.value = defaultAssignee;
+        }
+    }
+
+    function updateLeadSourceFromLocation() {
+        if (!leadSourceField || !stateField) {
+            return;
+        }
+
+        var provinceVal = stateField.value;
+
+        if (!provinceVal) {
+            leadSourceField.value = '';
+            applyOwner('');
+            return;
+        }
+
+        var leadSource = sourceMap.hasOwnProperty(provinceVal) ? String(sourceMap[provinceVal]) : '';
+
+        if (provinceVal === 'British Columbia') {
+            var cityVal = cityField ? cityField.value.trim().toLowerCase() : '';
+            for (var i = 0; i < bcCitiesKeywords.length; i++) {
+                if (cityVal.indexOf(bcCitiesKeywords[i]) !== -1) {
+                    leadSource = '2';
+                    break;
+                }
+            }
+        }
+
+        leadSourceField.value = leadSource;
+        applyOwner(leadSource);
+    }
+
+    if (stateField) {
+        stateField.addEventListener('change', updateLeadSourceFromLocation);
+    }
+
+    if (cityField) {
+        cityField.addEventListener('change', updateLeadSourceFromLocation);
+        cityField.addEventListener('keyup', updateLeadSourceFromLocation);
+    }
+
+    if (leadSourceField) {
+        leadSourceField.addEventListener('change', function () {
+            applyOwner(leadSourceField.value);
+        });
+    }
+
+    updateLeadSourceFromLocation();
+    if (leadSourceField) {
+        applyOwner(leadSourceField.value);
+    }
+})();
+</script>

--- a/app/Views/external_tickets/ticket_html_form_code.php
+++ b/app/Views/external_tickets/ticket_html_form_code.php
@@ -123,9 +123,23 @@
     var assignedField = document.getElementById('assigned_to');
     var autoAssignField = document.getElementById('auto_assign_owner');
 
-    var defaultAssignee = assignedField ? (assignedField.getAttribute('data-default-value') || assignedField.value || '') : '';
+    var defaultAssignee = '';
+    var hasDefaultAssignee = false;
 
-    var shouldAutoAssign = !!assignedField;
+    if (assignedField) {
+        var storedDefault = assignedField.getAttribute('data-default-value');
+        if (storedDefault !== null && typeof storedDefault !== 'undefined' && storedDefault !== '') {
+            defaultAssignee = storedDefault;
+        } else if (assignedField.value) {
+            defaultAssignee = assignedField.value;
+        }
+
+        if (defaultAssignee !== null && typeof defaultAssignee !== 'undefined' && defaultAssignee !== '') {
+            hasDefaultAssignee = true;
+        }
+    }
+
+    var shouldAutoAssign = !!assignedField && !hasDefaultAssignee;
 
     if (assignedField) {
         var ownerAutoAttr = assignedField.getAttribute('data-owner-auto');

--- a/app/Views/external_tickets/ticket_html_form_code.php
+++ b/app/Views/external_tickets/ticket_html_form_code.php
@@ -6,7 +6,8 @@
     <?php
     $default_assignee_id = !empty($selected_assignee_id) ? htmlspecialchars($selected_assignee_id) : "";
     ?>
-    <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" />
+    <input type="hidden" name="assigned_to" id="assigned_to" value="<?php echo $default_assignee_id; ?>" data-default-value="<?php echo $default_assignee_id; ?>" data-owner-auto="1" />
+    <input type="hidden" name="auto_assign_owner" id="auto_assign_owner" value="1" />
 
     <?php if (!empty($selected_label_ids)) { ?>
         <input type="hidden" name="labels" value="<?php echo htmlspecialchars($selected_label_ids); ?>" />
@@ -120,8 +121,26 @@
     var cityField = document.getElementById('city');
     var leadSourceField = document.getElementById('lead_source_id');
     var assignedField = document.getElementById('assigned_to');
+    var autoAssignField = document.getElementById('auto_assign_owner');
 
     var defaultAssignee = assignedField ? (assignedField.getAttribute('data-default-value') || assignedField.value || '') : '';
+
+    var shouldAutoAssign = !!assignedField;
+
+    if (assignedField) {
+        var ownerAutoAttr = assignedField.getAttribute('data-owner-auto');
+        if (ownerAutoAttr === '0') {
+            shouldAutoAssign = false;
+        }
+    }
+
+    if (autoAssignField) {
+        if (autoAssignField.value === '0') {
+            shouldAutoAssign = false;
+        }
+
+        autoAssignField.value = shouldAutoAssign ? '1' : '0';
+    }
 
     var ownerMap = {
         '2': '254',
@@ -159,7 +178,7 @@
     ];
 
     function applyOwner(leadSourceId) {
-        if (!assignedField) {
+        if (!assignedField || !shouldAutoAssign) {
             return;
         }
 

--- a/app/Views/external_tickets/ticket_html_form_code_modal_form.php
+++ b/app/Views/external_tickets/ticket_html_form_code_modal_form.php
@@ -1,0 +1,143 @@
+<div class="general-form">
+    <div class="modal-body clearfix">
+        <div class="container-fluid">
+            <div class="form-group">
+                <div class="row">
+                    <label for="ticket_html_ticket_type_id" class="col-md-3"><?php echo app_lang('ticket_type'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $ticket_type_dropdown = array('' => "- " . app_lang('ticket_type') . " -");
+                        if (!empty($ticket_types)) {
+                            foreach ($ticket_types as $type) {
+                                $ticket_type_dropdown[$type->id] = $type->title;
+                            }
+                        }
+                        echo form_dropdown('ticket_html_ticket_type_id', $ticket_type_dropdown, '', "class='select2' id='ticket_html_ticket_type_id'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="ticket_html_assigned_to" class="col-md-3"><?php echo app_lang('assign_to'); ?></label>
+                    <div class="col-md-9">
+                        <?php
+                        $assignee_dropdown = array('' => "- " . app_lang('assign_to') . " -");
+                        if (!empty($assignees)) {
+                            foreach ($assignees as $member) {
+                                $full_name = trim($member->first_name . ' ' . $member->last_name);
+                                $assignee_dropdown[$member->id] = $full_name ? $full_name : $member->first_name;
+                            }
+                        }
+                        echo form_dropdown('ticket_html_assigned_to', $assignee_dropdown, '', "class='select2' id='ticket_html_assigned_to'");
+                        ?>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="ticket_html_labels" class="col-md-3"><?php echo app_lang('labels'); ?></label>
+                    <div class="col-md-9">
+                        <select id="ticket_html_labels" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($labels)) {
+                                foreach ($labels as $label) { ?>
+                                    <option value="<?php echo htmlspecialchars($label->id); ?>"><?php echo htmlspecialchars($label->title); ?></option>
+                                <?php }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <label for="ticket_html_custom_fields" class="col-md-3"><?php echo app_lang('custom_fields'); ?></label>
+                    <div class="col-md-9">
+                        <select id="ticket_html_custom_fields" class="select2" multiple="multiple" style="width: 100%;">
+                            <?php if (!empty($custom_fields)) {
+                                foreach ($custom_fields as $field) {
+                                    $field_title = $field->title_language_key ? app_lang($field->title_language_key) : $field->title;
+                                    ?>
+                                    <option value="<?php echo htmlspecialchars($field->id); ?>"><?php echo htmlspecialchars($field_title); ?></option>
+                                <?php }
+                            } ?>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-md-12">
+                        <?php
+                        echo form_textarea(array(
+                            'id' => 'ticket-html-form-code',
+                            'name' => 'ticket-html-form-code',
+                            'value' => $ticket_html_form_code,
+                            'class' => 'form-control'
+                        ));
+                        ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-bs-dismiss="modal"><span data-feather="x" class="icon-16"></span> <?php echo app_lang('close'); ?></button>
+        <button type="button" id="ticket-html-copy-button" class="btn btn-primary"><span data-feather="copy" class="icon-16"></span> <?php echo app_lang('copy'); ?></button>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#ticket-html-form-code").addClass("h370");
+        $(".select2").select2();
+
+        function collectPostData() {
+            var data = {};
+
+            var ticketType = $("#ticket_html_ticket_type_id").val();
+            if (ticketType) {
+                data.ticket_type_id = ticketType;
+            }
+
+            var assignee = $("#ticket_html_assigned_to").val();
+            if (assignee) {
+                data.assigned_to = assignee;
+            }
+
+            var labels = $("#ticket_html_labels").val();
+            if (labels && labels.length) {
+                data.labels = labels;
+            }
+
+            var customFields = $("#ticket_html_custom_fields").val();
+            if (customFields && customFields.length) {
+                data.custom_fields = customFields;
+            }
+
+            return data;
+        }
+
+        function updateHtmlCode() {
+            $.ajax({
+                url: "<?php echo get_uri('external_tickets/get_ticket_html_form_code'); ?>",
+                type: "POST",
+                data: collectPostData(),
+                success: function (result) {
+                    $("#ticket-html-form-code").val(result);
+                }
+            });
+        }
+
+        $("#ticket_html_ticket_type_id, #ticket_html_assigned_to").on("change", updateHtmlCode);
+        $("#ticket_html_labels, #ticket_html_custom_fields").on("change", updateHtmlCode);
+
+        updateHtmlCode();
+
+        $("#ticket-html-copy-button").click(function () {
+            var copyTextarea = document.querySelector('#ticket-html-form-code');
+            copyTextarea.focus();
+            copyTextarea.select();
+            document.execCommand('copy');
+        });
+    });
+</script>

--- a/app/Views/settings/tickets/index.php
+++ b/app/Views/settings/tickets/index.php
@@ -90,6 +90,9 @@
                     <span class="ml10 <?php echo get_setting('enable_embedded_form_to_get_tickets') ? "" : "hide"; ?>" id="external_form_embedded_url">
                         <?php echo modal_anchor(get_uri("external_tickets/embedded_code_modal_form"), "<i data-feather='code' class='icon-16'></i>", array("title" => app_lang('embed'), "class" => "edit external-tickets-embedded-code")) ?>
                     </span>
+                    <span class="ml10 <?php echo get_setting('enable_embedded_form_to_get_tickets') ? "" : "hide"; ?>" id="ticket_html_form_code">
+                        <?php echo modal_anchor(get_uri("external_tickets/ticket_html_form_code_modal_form"), "<i data-feather='code' class='icon-16'></i>", array("title" => app_lang('ticket_html_form_code'), "class" => "edit external-tickets-embedded-code")) ?>
+                    </span>
                 </div>
             </div>
         </div>
@@ -125,8 +128,10 @@
         $("#enable_embedded_form_to_get_tickets").click(function () {
             if ($(this).is(":checked")) {
                 $("#external_form_embedded_url").removeClass("hide");
+                $("#ticket_html_form_code").removeClass("hide");
             } else {
                 $("#external_form_embedded_url").addClass("hide");
+                $("#ticket_html_form_code").addClass("hide");
             }
         });
 


### PR DESCRIPTION
## Summary
- update the external ticket HTML embed generator to respect each custom field's metadata
- render select-type custom fields as dropdowns with their configured options and required state

## Testing
- php -l app/Views/external_tickets/ticket_html_form_code.php

------
https://chatgpt.com/codex/tasks/task_e_68dd3014b4b48332934c7e2062983e59