### PR TITLE
Add lead label summary report

### DIFF
--- a/app/Controllers/Lead_reports.php
+++ b/app/Controllers/Lead_reports.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Controllers;
+
+class Lead_reports extends Security_Controller {
+
+    public function __construct() {
+        parent::__construct();
+        $this->access_only_team_members();
+    }
+
+    public function lead_label_summary() {
+        $this->_validate_lead_access();
+
+        $selected_source = $this->_get_filter_value("source_value");
+        $view_data["sources_dropdown"] = json_encode($this->_get_sources_dropdown($selected_source));
+
+        return $this->template->rander("lead_reports/lead_label_summary", $view_data);
+    }
+
+    public function lead_label_summary_list() {
+        $this->_validate_lead_access();
+
+        $filters = array(
+            "source_value" => $this->_get_filter_value("source_value"),
+            "start_date" => $this->_get_filter_value("start_date"),
+            "end_date" => $this->_get_filter_value("end_date")
+        );
+
+        $summary = $this->Clients_model->get_lead_label_summary($filters);
+        $label_counts = get_array_value($summary, "label_counts", array());
+        $no_label_count = intval(get_array_value($summary, "no_label_count", 0));
+
+        $rows = array();
+        if ($label_counts) {
+            foreach ($label_counts as $label_info) {
+                $total = isset($label_info->total_count) ? intval($label_info->total_count) : 0;
+
+                $rows[] = array(
+                    $label_info->label_title,
+                    to_decimal_format($total)
+                );
+            }
+        }
+
+        $rows[] = array(app_lang("no_label"), to_decimal_format($no_label_count));
+
+        echo json_encode(array("data" => $rows));
+    }
+
+    private function _get_sources_dropdown($selected_source_value = null) {
+        $sources = $this->Clients_model->get_lead_conversion_source_values(238)->getResult();
+        $selected_source_value = $selected_source_value !== null ? trim($selected_source_value) : $selected_source_value;
+
+        $dropdown = array(array(
+            "id" => "",
+            "text" => "- " . app_lang("source") . " -",
+            "isSelected" => ($selected_source_value === null || $selected_source_value === "")
+        ));
+
+        foreach ($sources as $source) {
+            $value = trim($source->value);
+            $dropdown[] = array(
+                "id" => $value,
+                "text" => $value,
+                "isSelected" => ($selected_source_value !== null && $selected_source_value !== "" && $selected_source_value === $value)
+            );
+        }
+
+        return $dropdown;
+    }
+
+    private function _get_filter_value($key) {
+        $value = $this->request->getPost($key);
+
+        if ($value === null) {
+            $value = $this->request->getGet($key);
+        }
+
+        if (is_string($value)) {
+            $value = trim($value);
+        }
+
+        return $value;
+    }
+
+    private function _validate_lead_access() {
+        if (get_setting("module_lead") != "1") {
+            app_redirect("forbidden");
+        }
+
+        $lead_permission = get_array_value($this->login_user->permissions, "lead");
+        if (!($this->login_user->is_admin || $lead_permission === "all")) {
+            app_redirect("forbidden");
+        }
+    }
+}
+
+/* End of file Lead_reports.php */
+/* Location: ./app/controllers/Lead_reports.php */

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -106,7 +106,8 @@ if (!function_exists('get_reports_topbar')) {
             $lead_reports_dropdown = array(
                 "lead_conversion_report" => array("name" => "lead_conversion_report", "url" => "lead_conversion_reports"),
                 "client_conversion_timeline" => array("name" => "client_conversion_timeline", "url" => "lead_conversion_reports/client_timeline"),
-                "rep_conversion_rates" => array("name" => "rep_conversion_rates", "url" => "lead_conversion_reports/rep_conversion_rates")
+                "rep_conversion_rates" => array("name" => "rep_conversion_rates", "url" => "lead_conversion_reports/rep_conversion_rates"),
+                "lead_label_summary" => array("name" => "lead_label_summary", "url" => "lead_reports/lead_label_summary")
             );
 
             $reports_menu["client_reports"] = array("name" => "client_reports", "url" => "clients/clients_report", "class" => "users", "dropdown_item" => $client_reports_dropdown);

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2804,6 +2804,8 @@ $lang["lead_reports"] = "Lead reports";
 $lang["converted_to_client_report"] = "Converted to opportunity report";
 $lang["client_conversion_timeline"] = "Opportunity conversion timeline";
 $lang["rep_conversion_rates"] = "Rep conversion rates";
+$lang["lead_label_summary"] = "Lead label summary";
+$lang["no_label"] = "No label";
 
 $lang["opportunities_graphs"] = "Opportunities Graphs";
 $lang["opportunity_data_reports"] = "Opportunity Data Reports";

--- a/app/Views/lead_reports/lead_label_summary.php
+++ b/app/Views/lead_reports/lead_label_summary.php
@@ -1,0 +1,30 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="table-responsive">
+            <table id="lead-label-summary-table" class="display" width="100%"></table>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $("#lead-label-summary-table").appTable({
+            source: '<?php echo_uri("lead_reports/lead_label_summary_list"); ?>',
+            filterDropdown: [
+                {name: "source_value", class: "w200", options: <?php echo $sources_dropdown; ?>}
+            ],
+            rangeDatepicker: [
+                {startDate: {name: "start_date", value: ""}, endDate: {name: "end_date", value: ""}, label: "<?php echo app_lang('created_date'); ?>", showClearButton: true}
+            ],
+            columns: [
+                {title: "<?php echo app_lang('label'); ?>", class: "all"},
+                {title: "<?php echo app_lang('total_leads'); ?>", class: "text-right"}
+            ],
+            order: [[1, "desc"]],
+            printColumns: [0, 1],
+            xlsColumns: [0, 1]
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- add a lead label summary report that lists lead counts by label with source and date filters
- aggregate lead label metrics through a new Clients_model helper and expose the view/controller for the report
- extend the reports helper and language strings to surface the new menu entry

## Testing
- php -l app/Controllers/Lead_reports.php
- php -l app/Models/Clients_model.php

------
https://chatgpt.com/codex/tasks/task_b_68e3b172d824832a9af6c06cbf964942