### PR TITLE
Add campaign pipeline report and update marketing source fields

### DIFF
--- a/app/Controllers/Collect_leads.php
+++ b/app/Controllers/Collect_leads.php
@@ -6,7 +6,7 @@ use App\Libraries\ReCAPTCHA;
 
 class Collect_leads extends App_Controller {
 
-    private const SOURCE_CUSTOM_FIELD_ID = 265;
+    private const SOURCE_CUSTOM_FIELD_ID = 138;
 
     function __construct() {
         parent::__construct();

--- a/app/Controllers/Collect_leads.php
+++ b/app/Controllers/Collect_leads.php
@@ -6,7 +6,7 @@ use App\Libraries\ReCAPTCHA;
 
 class Collect_leads extends App_Controller {
 
-    private const SOURCE_CUSTOM_FIELD_ID = 138;
+    private const SOURCE_CUSTOM_FIELD_ID = 238;
 
     function __construct() {
         parent::__construct();

--- a/app/Controllers/Lead_reports.php
+++ b/app/Controllers/Lead_reports.php
@@ -143,11 +143,25 @@ class Lead_reports extends Security_Controller {
         $this->_validate_lead_access();
 
         $campaigns = $this->_normalize_campaign_filter_values($this->_get_filter_value("campaign"));
-        $response = $this->Clients_model->get_campaign_pipeline_breakdown(array(
+        $breakdown = $this->Clients_model->get_campaign_pipeline_breakdown(array(
                     "campaign" => $campaigns
         ));
 
-        echo json_encode($response);
+        $rows = array();
+        $campaign_rows = get_array_value($breakdown, "campaigns", array());
+
+        if ($campaign_rows) {
+            foreach ($campaign_rows as $campaign_row) {
+                $rows[] = array(
+                    get_array_value($campaign_row, "label", app_lang("not_specified")),
+                    to_decimal_format(intval(get_array_value($campaign_row, "assigned", 0))),
+                    to_decimal_format(intval(get_array_value($campaign_row, "unassigned", 0))),
+                    to_decimal_format(intval(get_array_value($campaign_row, "total", 0)))
+                );
+            }
+        }
+
+        echo json_encode(array("data" => $rows));
     }
 
     private function _get_date_range_label($start_date, $end_date) {

--- a/app/Controllers/Lead_reports.php
+++ b/app/Controllers/Lead_reports.php
@@ -203,11 +203,45 @@ class Lead_reports extends Security_Controller {
             $value = $this->request->getGet($key);
         }
 
+        if ($value === null && $key !== "filter_params") {
+            $filter_params = $this->_get_filter_params_array();
+            if (array_key_exists($key, $filter_params)) {
+                $value = $filter_params[$key];
+            }
+        }
+
         if (is_string($value)) {
             $value = trim($value);
         }
 
         return $value;
+    }
+
+    private function _get_filter_params_array() {
+        $filter_params = $this->request->getPost("filter_params");
+
+        if ($filter_params === null) {
+            $filter_params = $this->request->getGet("filter_params");
+        }
+
+        if ($filter_params === null || $filter_params === "") {
+            return array();
+        }
+
+        if (is_array($filter_params)) {
+            return $filter_params;
+        }
+
+        if (is_string($filter_params)) {
+            $filter_params = trim($filter_params);
+        }
+
+        $decoded = json_decode($filter_params, true);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+            return $decoded;
+        }
+
+        return array();
     }
 
     private function _normalize_campaign_filter_values($value) {

--- a/app/Helpers/reports_helper.php
+++ b/app/Helpers/reports_helper.php
@@ -107,7 +107,8 @@ if (!function_exists('get_reports_topbar')) {
                 "lead_conversion_report" => array("name" => "lead_conversion_report", "url" => "lead_conversion_reports"),
                 "client_conversion_timeline" => array("name" => "client_conversion_timeline", "url" => "lead_conversion_reports/client_timeline"),
                 "rep_conversion_rates" => array("name" => "rep_conversion_rates", "url" => "lead_conversion_reports/rep_conversion_rates"),
-                "lead_label_summary" => array("name" => "lead_label_summary", "url" => "lead_reports/lead_label_summary")
+                "lead_label_summary" => array("name" => "lead_label_summary", "url" => "lead_reports/lead_label_summary"),
+                "campaign_pipeline" => array("name" => "campaign_pipeline", "url" => "lead_reports/campaign_pipeline")
             );
 
             $reports_menu["client_reports"] = array("name" => "client_reports", "url" => "clients/clients_report", "class" => "users", "dropdown_item" => $client_reports_dropdown);

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -1660,7 +1660,7 @@ $lang["lead_import_format_meta"] = "Meta leads template";
 $lang["lead_import_meta_lead_type"] = "Meta lead type";
 $lang["lead_import_meta_person"] = "Person";
 $lang["lead_import_meta_organization"] = "Organization";
-$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 138, set the owner to 309, and only import leads in the Qualified stage.";
+$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 238, set the owner to 309, and only import leads in the Qualified stage.";
 
 $lang["deadline_must_be_equal_or_greater_than_start_date"] = "Deadline must be equal or greater than Start date.";
 

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -1660,7 +1660,7 @@ $lang["lead_import_format_meta"] = "Meta leads template";
 $lang["lead_import_meta_lead_type"] = "Meta lead type";
 $lang["lead_import_meta_person"] = "Person";
 $lang["lead_import_meta_organization"] = "Organization";
-$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 238, set the owner to 309, and only import leads in the Qualified stage.";
+$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 138, set the owner to 309, and only import leads in the Qualified stage.";
 
 $lang["deadline_must_be_equal_or_greater_than_start_date"] = "Deadline must be equal or greater than Start date.";
 
@@ -2813,6 +2813,10 @@ $lang["converted_to_client_report"] = "Converted to opportunity report";
 $lang["client_conversion_timeline"] = "Opportunity conversion timeline";
 $lang["rep_conversion_rates"] = "Rep conversion rates";
 $lang["lead_label_summary"] = "Lead label summary";
+$lang["campaign"] = "Campaign";
+$lang["campaign_pipeline"] = "Campaign pipeline";
+$lang["campaign_pipeline_summary"] = "Campaign pipeline summary";
+$lang["campaign_pipeline_breakdown"] = "Campaign pipeline breakdown";
 $lang["no_label"] = "No label";
 $lang["all_time"] = "All Time";
 

--- a/app/Language/english/custom_lang.php
+++ b/app/Language/english/custom_lang.php
@@ -2816,7 +2816,9 @@ $lang["lead_label_summary"] = "Lead label summary";
 $lang["campaign"] = "Campaign";
 $lang["campaign_pipeline"] = "Campaign pipeline";
 $lang["campaign_pipeline_summary"] = "Campaign pipeline summary";
-$lang["campaign_pipeline_breakdown"] = "Campaign pipeline breakdown";
+$lang["campaign_pipeline_breakdown"] = "Assigned vs unassigned per campaign";
+$lang["assigned_reps"] = "Assigned reps";
+$lang["unassigned_reps"] = "Unassigned reps";
 $lang["no_label"] = "No label";
 $lang["all_time"] = "All Time";
 

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -1660,7 +1660,7 @@ $lang["lead_import_format_meta"] = "Meta leads template";
 $lang["lead_import_meta_lead_type"] = "Meta lead type";
 $lang["lead_import_meta_person"] = "Person";
 $lang["lead_import_meta_organization"] = "Organization";
-$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 238, set the owner to 309, and only import leads in the Qualified stage.";
+$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 138, set the owner to 309, and only import leads in the Qualified stage.";
 
 $lang["deadline_must_be_equal_or_greater_than_start_date"] = "Deadline must be equal or greater than Start date.";
 
@@ -2815,6 +2815,11 @@ $lang["got_it"] = "Got it!";
 $lang["empty_comment_cannot_be_saved"] = "Empty comment cannot be saved.";
 
 $lang["short_ticket_templates"] = "Templates";
+
+$lang["campaign"] = "Campaign";
+$lang["campaign_pipeline"] = "Campaign pipeline";
+$lang["campaign_pipeline_summary"] = "Campaign pipeline summary";
+$lang["campaign_pipeline_breakdown"] = "Campaign pipeline breakdown";
 
 /* Version 3.8.2 */
 $lang["skype"] = "CC";

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -2819,7 +2819,9 @@ $lang["short_ticket_templates"] = "Templates";
 $lang["campaign"] = "Campaign";
 $lang["campaign_pipeline"] = "Campaign pipeline";
 $lang["campaign_pipeline_summary"] = "Campaign pipeline summary";
-$lang["campaign_pipeline_breakdown"] = "Campaign pipeline breakdown";
+$lang["campaign_pipeline_breakdown"] = "Assigned vs unassigned per campaign";
+$lang["assigned_reps"] = "Assigned reps";
+$lang["unassigned_reps"] = "Unassigned reps";
 
 /* Version 3.8.2 */
 $lang["skype"] = "CC";

--- a/app/Language/english/default_lang.php
+++ b/app/Language/english/default_lang.php
@@ -1660,7 +1660,7 @@ $lang["lead_import_format_meta"] = "Meta leads template";
 $lang["lead_import_meta_lead_type"] = "Meta lead type";
 $lang["lead_import_meta_person"] = "Person";
 $lang["lead_import_meta_organization"] = "Organization";
-$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 138, set the owner to 309, and only import leads in the Qualified stage.";
+$lang["lead_import_meta_help_text"] = "Meta lead imports preserve the Created column as the lead's created date, map the Form column to Custom Field 238, set the owner to 309, and only import leads in the Qualified stage.";
 
 $lang["deadline_must_be_equal_or_greater_than_start_date"] = "Deadline must be equal or greater than Start date.";
 

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -5,8 +5,8 @@ namespace App\Models;
 class Clients_model extends Crud_model {
 
     protected $table = null;
-    public const LEAD_SOURCE_CUSTOM_FIELD_ID = 138;
-    public const CLIENT_SOURCE_CUSTOM_FIELD_ID = 165;
+    public const LEAD_SOURCE_CUSTOM_FIELD_ID = 238;
+    public const CLIENT_SOURCE_CUSTOM_FIELD_ID = 265;
 
     function __construct() {
         $this->table = 'clients';
@@ -1058,8 +1058,8 @@ function get_details($options = array()) {
                 . "    FROM $clients_table AS leads"
                 . "    LEFT JOIN $custom_field_values_table AS lead_cf ON lead_cf.related_to_type='leads'"
                 . "        AND lead_cf.related_to_id=leads.id AND lead_cf.deleted=0 AND lead_cf.custom_field_id=$lead_source_custom_field_id"
-                . "    WHERE leads.deleted=0 AND leads.is_lead=1"
-                . "UNION ALL"
+                . "    WHERE leads.deleted=0 AND leads.is_lead=1 "
+                . "UNION ALL "
                 . "    SELECT clients.owner_id,"
                 . "       clients.lead_status_id,"
                 . "       'client' AS record_type,"

--- a/app/Models/Clients_model.php
+++ b/app/Models/Clients_model.php
@@ -1022,6 +1022,10 @@ function get_details($options = array()) {
         }
 
         if (!empty($campaign_values)) {
+            $campaign_rows = array_intersect_key($campaign_rows, array_flip($campaign_values));
+        }
+
+        if (!empty($campaign_values)) {
             foreach ($campaign_values as $selected_value) {
                 $selected_value = trim($selected_value);
                 if (!isset($campaign_rows[$selected_value])) {
@@ -1107,6 +1111,10 @@ function get_details($options = array()) {
                     'total' => $assigned + $unassigned
                 );
             }
+        }
+
+        if (!empty($campaign_values)) {
+            $campaign_map = array_intersect_key($campaign_map, array_flip($campaign_values));
         }
 
         if (!empty($campaign_values)) {

--- a/app/Views/collect_leads/embedded_code_modal_form.php
+++ b/app/Views/collect_leads/embedded_code_modal_form.php
@@ -64,15 +64,15 @@
             <?php if (!empty($source_custom_field_label)) { ?>
             <div class="form-group">
                 <div class="row">
-                    <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
                     <div class="col-md-9">
                         <?php
                         if (!empty($source_custom_field_has_options)) {
-                            echo form_dropdown("custom_field_265", $source_custom_field_options, '', "class='select2' id='custom_field_265'");
+                            echo form_dropdown("custom_field_138", $source_custom_field_options, '', "class='select2' id='custom_field_138'");
                         } else {
                             echo form_input(array(
-                                "id" => "custom_field_265",
-                                "name" => "custom_field_265",
+                                "id" => "custom_field_138",
+                                "name" => "custom_field_138",
                                 "class" => "form-control",
                                 "placeholder" => $source_custom_field_label
                             ));
@@ -107,7 +107,7 @@
         var formId = "";
         var customFieldValue = "";
         var customFieldOverride = false;
-        var $customField = $("#custom_field_265");
+        var $customField = $("#custom_field_138");
 
         if ($customField.length) {
             customFieldValue = $customField.val() || "";
@@ -173,7 +173,7 @@
                 var iframeSrc = "<?php echo get_uri('collect_leads/form/'); ?>" + formId;
                 if (includeCustomField) {
                     var separator = iframeSrc.indexOf('?') === -1 ? '?' : '&';
-                    iframeSrc += separator + "custom_field_265=" + encodeURIComponent(customFieldValue);
+                    iframeSrc += separator + "custom_field_138=" + encodeURIComponent(customFieldValue);
                 }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);
@@ -182,7 +182,7 @@
                 var iframeSrc = src + (sourceId ? sourceId : "0") + "/" + (ownerId ? ownerId : "0");
                 if (includeCustomField) {
                     var glue = iframeSrc.indexOf('?') === -1 ? '?' : '&';
-                    iframeSrc += glue + "custom_field_265=" + encodeURIComponent(customFieldValue);
+                    iframeSrc += glue + "custom_field_138=" + encodeURIComponent(customFieldValue);
                 }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);

--- a/app/Views/collect_leads/embedded_code_modal_form.php
+++ b/app/Views/collect_leads/embedded_code_modal_form.php
@@ -64,15 +64,15 @@
             <?php if (!empty($source_custom_field_label)) { ?>
             <div class="form-group">
                 <div class="row">
-                    <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <label for="custom_field_238" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
                     <div class="col-md-9">
                         <?php
                         if (!empty($source_custom_field_has_options)) {
-                            echo form_dropdown("custom_field_138", $source_custom_field_options, '', "class='select2' id='custom_field_138'");
+                            echo form_dropdown("custom_field_238", $source_custom_field_options, '', "class='select2' id='custom_field_238'");
                         } else {
                             echo form_input(array(
-                                "id" => "custom_field_138",
-                                "name" => "custom_field_138",
+                                "id" => "custom_field_238",
+                                "name" => "custom_field_238",
                                 "class" => "form-control",
                                 "placeholder" => $source_custom_field_label
                             ));
@@ -107,7 +107,7 @@
         var formId = "";
         var customFieldValue = "";
         var customFieldOverride = false;
-        var $customField = $("#custom_field_138");
+        var $customField = $("#custom_field_238");
 
         if ($customField.length) {
             customFieldValue = $customField.val() || "";
@@ -173,7 +173,7 @@
                 var iframeSrc = "<?php echo get_uri('collect_leads/form/'); ?>" + formId;
                 if (includeCustomField) {
                     var separator = iframeSrc.indexOf('?') === -1 ? '?' : '&';
-                    iframeSrc += separator + "custom_field_138=" + encodeURIComponent(customFieldValue);
+                    iframeSrc += separator + "custom_field_238=" + encodeURIComponent(customFieldValue);
                 }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);
@@ -182,7 +182,7 @@
                 var iframeSrc = src + (sourceId ? sourceId : "0") + "/" + (ownerId ? ownerId : "0");
                 if (includeCustomField) {
                     var glue = iframeSrc.indexOf('?') === -1 ? '?' : '&';
-                    iframeSrc += glue + "custom_field_138=" + encodeURIComponent(customFieldValue);
+                    iframeSrc += glue + "custom_field_238=" + encodeURIComponent(customFieldValue);
                 }
                 var iframeHtml = "<iframe width='768' height='360' src='" + iframeSrc + "' frameborder='0'></iframe>";
                 $("#embedded-code").val(iframeHtml);

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -88,8 +88,8 @@ table.dataTable tbody td:first-child {
             <?php if (!empty($lead_labels)) { ?>
                 <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
             <?php } ?>
-            <?php if (isset($custom_field_265_value) && $custom_field_265_value !== "") { ?>
-                <input type="hidden" name="custom_field_265" value="<?php echo htmlspecialchars($custom_field_265_value); ?>" />
+            <?php if (isset($custom_field_138_value) && $custom_field_138_value !== "") { ?>
+                <input type="hidden" name="custom_field_138" value="<?php echo htmlspecialchars($custom_field_138_value); ?>" />
             <?php } ?>
 
             <!-- 3) Gather hidden fields list, if applicable -->

--- a/app/Views/collect_leads/index.php
+++ b/app/Views/collect_leads/index.php
@@ -88,8 +88,8 @@ table.dataTable tbody td:first-child {
             <?php if (!empty($lead_labels)) { ?>
                 <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
             <?php } ?>
-            <?php if (isset($custom_field_138_value) && $custom_field_138_value !== "") { ?>
-                <input type="hidden" name="custom_field_138" value="<?php echo htmlspecialchars($custom_field_138_value); ?>" />
+            <?php if (isset($custom_field_238_value) && $custom_field_238_value !== "") { ?>
+                <input type="hidden" name="custom_field_238" value="<?php echo htmlspecialchars($custom_field_238_value); ?>" />
             <?php } ?>
 
             <!-- 3) Gather hidden fields list, if applicable -->

--- a/app/Views/collect_leads/lead_form_modal_form.php
+++ b/app/Views/collect_leads/lead_form_modal_form.php
@@ -36,15 +36,15 @@
     <?php if (!empty($source_custom_field_label)) { ?>
     <div class="form-group">
         <div class="row">
-            <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+            <label for="custom_field_238" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
             <div class="col-md-9">
                 <?php
                 if (!empty($source_custom_field_has_options)) {
-                    echo form_dropdown("custom_field_138", $source_custom_field_options, $model_info->custom_source_value, "class='select2' id='custom_field_138'");
+                    echo form_dropdown("custom_field_238", $source_custom_field_options, $model_info->custom_source_value, "class='select2' id='custom_field_238'");
                 } else {
                     echo form_input(array(
-                        "id" => "custom_field_138",
-                        "name" => "custom_field_138",
+                        "id" => "custom_field_238",
+                        "name" => "custom_field_238",
                         "value" => $model_info->custom_source_value,
                         "class" => "form-control",
                         "placeholder" => $source_custom_field_label

--- a/app/Views/collect_leads/lead_form_modal_form.php
+++ b/app/Views/collect_leads/lead_form_modal_form.php
@@ -36,15 +36,15 @@
     <?php if (!empty($source_custom_field_label)) { ?>
     <div class="form-group">
         <div class="row">
-            <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+            <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
             <div class="col-md-9">
                 <?php
                 if (!empty($source_custom_field_has_options)) {
-                    echo form_dropdown("custom_field_265", $source_custom_field_options, $model_info->custom_source_value, "class='select2' id='custom_field_265'");
+                    echo form_dropdown("custom_field_138", $source_custom_field_options, $model_info->custom_source_value, "class='select2' id='custom_field_138'");
                 } else {
                     echo form_input(array(
-                        "id" => "custom_field_265",
-                        "name" => "custom_field_265",
+                        "id" => "custom_field_138",
+                        "name" => "custom_field_138",
                         "value" => $model_info->custom_source_value,
                         "class" => "form-control",
                         "placeholder" => $source_custom_field_label

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -9,8 +9,8 @@
     <?php if (!empty($lead_labels)) { ?>
         <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
     <?php } ?>
-    <?php if (isset($custom_field_138_value) && $custom_field_138_value !== "") { ?>
-        <input type="hidden" name="custom_field_138" value="<?php echo htmlspecialchars($custom_field_138_value); ?>" />
+    <?php if (isset($custom_field_238_value) && $custom_field_238_value !== "") { ?>
+        <input type="hidden" name="custom_field_238" value="<?php echo htmlspecialchars($custom_field_238_value); ?>" />
     <?php } ?>
 
     <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" />

--- a/app/Views/collect_leads/lead_html_form_code.php
+++ b/app/Views/collect_leads/lead_html_form_code.php
@@ -9,8 +9,8 @@
     <?php if (!empty($lead_labels)) { ?>
         <input type="hidden" name="lead_labels" value="<?php echo $lead_labels; ?>" />
     <?php } ?>
-    <?php if (isset($custom_field_265_value) && $custom_field_265_value !== "") { ?>
-        <input type="hidden" name="custom_field_265" value="<?php echo htmlspecialchars($custom_field_265_value); ?>" />
+    <?php if (isset($custom_field_138_value) && $custom_field_138_value !== "") { ?>
+        <input type="hidden" name="custom_field_138" value="<?php echo htmlspecialchars($custom_field_138_value); ?>" />
     <?php } ?>
 
     <input type="text" name="company_name" id="company_name" placeholder="<?php echo app_lang('company_name'); ?>" />

--- a/app/Views/collect_leads/lead_html_form_code_modal_form.php
+++ b/app/Views/collect_leads/lead_html_form_code_modal_form.php
@@ -46,15 +46,15 @@
             <?php if (!empty($source_custom_field_label)) { ?>
             <div class="form-group">
                 <div class="row">
-                    <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <label for="custom_field_238" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
                     <div class="col-md-9">
                         <?php
                         if (!empty($source_custom_field_has_options)) {
-                            echo form_dropdown('custom_field_138', $source_custom_field_options, '', "class='select2' id='custom_field_138'");
+                            echo form_dropdown('custom_field_238', $source_custom_field_options, '', "class='select2' id='custom_field_238'");
                         } else {
                             echo form_input(array(
-                                "id" => "custom_field_138",
-                                "name" => "custom_field_138",
+                                "id" => "custom_field_238",
+                                "name" => "custom_field_238",
                                 "class" => "form-control",
                                 "placeholder" => $source_custom_field_label
                             ));
@@ -98,7 +98,7 @@
         var formId = "";
         var customFieldValue = "";
         var customFieldOverride = false;
-        var $customField = $("#custom_field_138");
+        var $customField = $("#custom_field_238");
 
         if ($customField.length) {
             customFieldValue = $customField.val() || "";
@@ -116,7 +116,7 @@
             };
 
             if (shouldIncludeCustomField()) {
-                postData.custom_field_138 = customFieldValue;
+                postData.custom_field_238 = customFieldValue;
             }
 
             $.ajax({

--- a/app/Views/collect_leads/lead_html_form_code_modal_form.php
+++ b/app/Views/collect_leads/lead_html_form_code_modal_form.php
@@ -46,15 +46,15 @@
             <?php if (!empty($source_custom_field_label)) { ?>
             <div class="form-group">
                 <div class="row">
-                    <label for="custom_field_265" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
+                    <label for="custom_field_138" class="col-md-3"><?php echo $source_custom_field_label; ?></label>
                     <div class="col-md-9">
                         <?php
                         if (!empty($source_custom_field_has_options)) {
-                            echo form_dropdown('custom_field_265', $source_custom_field_options, '', "class='select2' id='custom_field_265'");
+                            echo form_dropdown('custom_field_138', $source_custom_field_options, '', "class='select2' id='custom_field_138'");
                         } else {
                             echo form_input(array(
-                                "id" => "custom_field_265",
-                                "name" => "custom_field_265",
+                                "id" => "custom_field_138",
+                                "name" => "custom_field_138",
                                 "class" => "form-control",
                                 "placeholder" => $source_custom_field_label
                             ));
@@ -98,7 +98,7 @@
         var formId = "";
         var customFieldValue = "";
         var customFieldOverride = false;
-        var $customField = $("#custom_field_265");
+        var $customField = $("#custom_field_138");
 
         if ($customField.length) {
             customFieldValue = $customField.val() || "";
@@ -116,7 +116,7 @@
             };
 
             if (shouldIncludeCustomField()) {
-                postData.custom_field_265 = customFieldValue;
+                postData.custom_field_138 = customFieldValue;
             }
 
             $.ajax({

--- a/app/Views/lead_reports/campaign_pipeline.php
+++ b/app/Views/lead_reports/campaign_pipeline.php
@@ -5,10 +5,10 @@
         <div class="p20">
             <h4 class="card-title"><?php echo app_lang("campaign_pipeline_summary"); ?></h4>
             <div class="row mb15">
-                <div class="col-md-3 col-sm-6">
+                <div class="col-md-4 col-sm-6">
                     <div class="form-group">
                         <label for="campaign-filter" class="form-label"><?php echo app_lang("campaign"); ?></label>
-                        <select id="campaign-filter" class="form-control select2"></select>
+                        <select id="campaign-filter" class="form-control select2" multiple="multiple"></select>
                     </div>
                 </div>
             </div>
@@ -21,9 +21,7 @@
     <div class="card clearfix mt20">
         <div class="p20">
             <h4 class="card-title"><?php echo app_lang("campaign_pipeline_breakdown"); ?></h4>
-            <div class="table-responsive">
-                <table id="campaign-pipeline-breakdown-table" class="display" width="100%"></table>
-            </div>
+            <div id="campaign-pipeline-breakdown-wrapper" class="clearfix"></div>
         </div>
     </div>
 </div>
@@ -31,73 +29,203 @@
 <script type="text/javascript">
     $(document).ready(function () {
         var campaignOptions = <?php echo $campaigns_dropdown; ?> || [];
+        var statusColumns = <?php echo $campaign_status_columns; ?> || [];
+        var initialCampaignSelection = <?php echo $selected_campaigns; ?> || [];
         var $campaignFilter = $("#campaign-filter");
-        var selectedCampaign = "";
+        var selectedCampaigns = [];
+        var placeholderText = "- <?php echo app_lang('campaign'); ?> -";
+        var formatNumber = function (value) {
+            var numericValue = parseFloat(value);
+            if (isNaN(numericValue)) {
+                numericValue = 0;
+            }
+
+            if (window.AppHelper && $.isFunction(AppHelper.numberFormat)) {
+                return AppHelper.numberFormat(numericValue);
+            }
+
+            return numericValue.toLocaleString();
+        };
 
         if (campaignOptions.length) {
             $.each(campaignOptions, function (index, option) {
+                if (!option.id) {
+                    placeholderText = option.text || placeholderText;
+                    return;
+                }
+
                 var $option = $("<option />").val(option.id).text(option.text);
-                if (option.isSelected) {
+                if (option.isSelected || $.inArray(option.id, initialCampaignSelection) !== -1) {
                     $option.prop("selected", true);
-                    selectedCampaign = option.id;
                 }
                 $campaignFilter.append($option);
             });
         }
 
-        $campaignFilter.select2();
+        $campaignFilter.select2({
+            placeholder: placeholderText,
+            allowClear: true
+        });
 
-        if (!selectedCampaign) {
-            selectedCampaign = $campaignFilter.val() || "";
+        selectedCampaigns = $campaignFilter.val() || [];
+
+        var summaryColumns = [{title: "<?php echo app_lang('campaign'); ?>", "class": "all"}];
+        var summaryColumnIndexes = [0];
+        var summarySummation = [];
+
+        if (statusColumns.length) {
+            $.each(statusColumns, function (index, column) {
+                summaryColumns.push({title: column.title, "class": "text-right"});
+                summaryColumnIndexes.push(summaryColumnIndexes.length);
+                summarySummation.push({column: summaryColumnIndexes.length - 1, dataType: 'number'});
+            });
         }
 
+        summaryColumns.push({title: "<?php echo app_lang('total'); ?>", "class": "text-right"});
+        summaryColumnIndexes.push(summaryColumnIndexes.length);
+        summarySummation.push({column: summaryColumnIndexes.length - 1, dataType: 'number'});
+
         var $summaryTable = $("#campaign-pipeline-summary-table");
-        var $breakdownTable = $("#campaign-pipeline-breakdown-table");
 
         $summaryTable.appTable({
             source: '<?php echo_uri("lead_reports/campaign_pipeline_summary_list"); ?>',
-            filterParams: {campaign: selectedCampaign},
-            columns: [
-                {title: "<?php echo app_lang('status'); ?>", "class": "all"},
-                {title: "<?php echo app_lang('leads'); ?>", "class": "text-right"},
-                {title: "<?php echo app_lang('clients'); ?>", "class": "text-right"},
-                {title: "<?php echo app_lang('total'); ?>", "class": "text-right"}
-            ],
-            order: [[0, "asc"]],
-            printColumns: [0, 1, 2, 3],
-            xlsColumns: [0, 1, 2, 3],
-            summation: [
-                {column: 1, dataType: 'number'},
-                {column: 2, dataType: 'number'},
-                {column: 3, dataType: 'number'}
-            ]
+            filterParams: {campaign: JSON.stringify(selectedCampaigns)},
+            columns: summaryColumns,
+            order: [],
+            printColumns: summaryColumnIndexes,
+            xlsColumns: summaryColumnIndexes,
+            summation: summarySummation
         });
 
-        $breakdownTable.appTable({
-            source: '<?php echo_uri("lead_reports/campaign_pipeline_breakdown_list"); ?>',
-            filterParams: {campaign: selectedCampaign},
-            order: [[0, "asc"], [1, "asc"], [2, "asc"]],
-            columns: [
-                {title: "<?php echo app_lang('campaign'); ?>", "class": "all"},
-                {title: "<?php echo app_lang('owner'); ?>", "class": "all"},
-                {title: "<?php echo app_lang('status'); ?>", "class": "all"},
-                {title: "<?php echo app_lang('leads'); ?>", "class": "text-right"},
-                {title: "<?php echo app_lang('clients'); ?>", "class": "text-right"},
-                {title: "<?php echo app_lang('total'); ?>", "class": "text-right"}
-            ],
-            printColumns: [0, 1, 2, 3, 4, 5],
-            xlsColumns: [0, 1, 2, 3, 4, 5],
-            summation: [
-                {column: 3, dataType: 'number'},
-                {column: 4, dataType: 'number'},
-                {column: 5, dataType: 'number'}
-            ]
-        });
+        var $breakdownWrapper = $("#campaign-pipeline-breakdown-wrapper");
+
+        var loadBreakdown = function () {
+            var requestData = {campaign: JSON.stringify(selectedCampaigns)};
+
+            $breakdownWrapper.find('table').each(function () {
+                if ($.fn.DataTable && $.fn.DataTable.isDataTable(this)) {
+                    $(this).DataTable().destroy();
+                }
+            });
+
+            $breakdownWrapper.empty();
+
+            appLoader.show();
+
+            $.ajax({
+                url: '<?php echo_uri("lead_reports/campaign_pipeline_breakdown_list"); ?>',
+                type: 'POST',
+                dataType: 'json',
+                data: requestData,
+                success: function (response) {
+                    appLoader.hide();
+
+                    if (response && response.status_definitions) {
+                        statusColumns = response.status_definitions;
+                    }
+
+                    var campaigns = (response && response.campaigns) ? response.campaigns : [];
+
+                    if (!campaigns.length) {
+                        $breakdownWrapper.append('<div class="text-center text-off p20">' + appLang('no_data_found') + '</div>');
+                        return;
+                    }
+
+                    $.each(campaigns, function (index, campaign) {
+                        var tableId = 'campaign-breakdown-table-' + index;
+                        var $card = $('<div class="card clearfix mb15"></div>');
+                        var $cardBody = $('<div class="p20"></div>').appendTo($card);
+                        $('<h5 class="card-title"></h5>').text(campaign.label || '').appendTo($cardBody);
+
+                        var $tableWrapper = $('<div class="table-responsive"></div>').appendTo($cardBody);
+                        var $table = $('<table class="display" width="100%"></table>').attr('id', tableId).appendTo($tableWrapper);
+
+                        var columns = [{title: "<?php echo app_lang('owner'); ?>", className: 'all'}];
+                        var exportColumns = [0];
+                        var tableData = [];
+
+                        if (statusColumns.length) {
+                            $.each(statusColumns, function (statusIndex, column) {
+                                columns.push({title: column.title, className: 'text-right'});
+                                exportColumns.push(exportColumns.length);
+                            });
+                        }
+
+                        columns.push({title: "<?php echo app_lang('total'); ?>", className: 'text-right'});
+                        exportColumns.push(exportColumns.length);
+
+                        var owners = campaign.owners || [];
+                        if (owners.length) {
+                            $.each(owners, function (ownerIndex, owner) {
+                                var row = [owner.owner_name || appLang('not_specified')];
+
+                                if (statusColumns.length) {
+                                    $.each(statusColumns, function (statusIndex, column) {
+                                var counts = owner.counts || {};
+                                var value = counts.hasOwnProperty(column.key) ? counts[column.key] : 0;
+                                row.push(formatNumber(value));
+                            });
+                        }
+
+                        row.push(formatNumber(owner.total || 0));
+                        tableData.push(row);
+                    });
+                }
+
+                var totals = campaign.totals || {counts: {}};
+                var $tfootRow = $('<tr></tr>');
+                $tfootRow.append($('<th></th>').text(appLang('total')));
+
+                if (statusColumns.length) {
+                    $.each(statusColumns, function (statusIndex, column) {
+                        var value = (totals.counts && totals.counts.hasOwnProperty(column.key)) ? totals.counts[column.key] : 0;
+                        $tfootRow.append($('<th class="text-right"></th>').text(formatNumber(value)));
+                    });
+                }
+
+                $tfootRow.append($('<th class="text-right"></th>').text(formatNumber(totals.total || 0)));
+
+                        var $tfoot = $('<tfoot></tfoot>').append($tfootRow);
+                        $table.append($tfoot);
+
+                        $breakdownWrapper.append($card);
+
+                        if ($.fn.DataTable) {
+                            $table.DataTable({
+                                data: tableData,
+                                columns: columns,
+                                paging: false,
+                                searching: false,
+                                ordering: false,
+                                info: false,
+                                dom: 'Bfrtip',
+                                buttons: [
+                                    {
+                                        extend: 'excel',
+                                        text: "<?php echo app_lang('export_to_excel'); ?>",
+                                        title: (campaign.label || '') + ' - <?php echo app_lang("campaign_pipeline_breakdown"); ?>',
+                                        exportOptions: {
+                                            columns: exportColumns
+                                        }
+                                    }
+                                ]
+                            });
+                        }
+                    });
+                },
+                error: function () {
+                    appLoader.hide();
+                    $breakdownWrapper.append('<div class="text-center text-danger p20">' + appLang('something_went_wrong') + '</div>');
+                }
+            });
+        };
+
+        loadBreakdown();
 
         $campaignFilter.on("change", function () {
-            selectedCampaign = $(this).val() || "";
-            $summaryTable.appTable({reload: true, filterParams: {campaign: selectedCampaign}});
-            $breakdownTable.appTable({reload: true, filterParams: {campaign: selectedCampaign}});
+            selectedCampaigns = $(this).val() || [];
+            $summaryTable.appTable({reload: true, filterParams: {campaign: JSON.stringify(selectedCampaigns)}});
+            loadBreakdown();
         });
     });
 </script>

--- a/app/Views/lead_reports/campaign_pipeline.php
+++ b/app/Views/lead_reports/campaign_pipeline.php
@@ -1,0 +1,103 @@
+<?php echo get_reports_topbar(); ?>
+
+<div id="page-content" class="page-wrapper clearfix">
+    <div class="card clearfix">
+        <div class="p20">
+            <h4 class="card-title"><?php echo app_lang("campaign_pipeline_summary"); ?></h4>
+            <div class="row mb15">
+                <div class="col-md-3 col-sm-6">
+                    <div class="form-group">
+                        <label for="campaign-filter" class="form-label"><?php echo app_lang("campaign"); ?></label>
+                        <select id="campaign-filter" class="form-control select2"></select>
+                    </div>
+                </div>
+            </div>
+            <div class="table-responsive">
+                <table id="campaign-pipeline-summary-table" class="display" width="100%"></table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card clearfix mt20">
+        <div class="p20">
+            <h4 class="card-title"><?php echo app_lang("campaign_pipeline_breakdown"); ?></h4>
+            <div class="table-responsive">
+                <table id="campaign-pipeline-breakdown-table" class="display" width="100%"></table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        var campaignOptions = <?php echo $campaigns_dropdown; ?> || [];
+        var $campaignFilter = $("#campaign-filter");
+        var selectedCampaign = "";
+
+        if (campaignOptions.length) {
+            $.each(campaignOptions, function (index, option) {
+                var $option = $("<option />").val(option.id).text(option.text);
+                if (option.isSelected) {
+                    $option.prop("selected", true);
+                    selectedCampaign = option.id;
+                }
+                $campaignFilter.append($option);
+            });
+        }
+
+        $campaignFilter.select2();
+
+        if (!selectedCampaign) {
+            selectedCampaign = $campaignFilter.val() || "";
+        }
+
+        var $summaryTable = $("#campaign-pipeline-summary-table");
+        var $breakdownTable = $("#campaign-pipeline-breakdown-table");
+
+        $summaryTable.appTable({
+            source: '<?php echo_uri("lead_reports/campaign_pipeline_summary_list"); ?>',
+            filterParams: {campaign: selectedCampaign},
+            columns: [
+                {title: "<?php echo app_lang('status'); ?>", "class": "all"},
+                {title: "<?php echo app_lang('leads'); ?>", "class": "text-right"},
+                {title: "<?php echo app_lang('clients'); ?>", "class": "text-right"},
+                {title: "<?php echo app_lang('total'); ?>", "class": "text-right"}
+            ],
+            order: [[0, "asc"]],
+            printColumns: [0, 1, 2, 3],
+            xlsColumns: [0, 1, 2, 3],
+            summation: [
+                {column: 1, dataType: 'number'},
+                {column: 2, dataType: 'number'},
+                {column: 3, dataType: 'number'}
+            ]
+        });
+
+        $breakdownTable.appTable({
+            source: '<?php echo_uri("lead_reports/campaign_pipeline_breakdown_list"); ?>',
+            filterParams: {campaign: selectedCampaign},
+            order: [[0, "asc"], [1, "asc"], [2, "asc"]],
+            columns: [
+                {title: "<?php echo app_lang('campaign'); ?>", "class": "all"},
+                {title: "<?php echo app_lang('owner'); ?>", "class": "all"},
+                {title: "<?php echo app_lang('status'); ?>", "class": "all"},
+                {title: "<?php echo app_lang('leads'); ?>", "class": "text-right"},
+                {title: "<?php echo app_lang('clients'); ?>", "class": "text-right"},
+                {title: "<?php echo app_lang('total'); ?>", "class": "text-right"}
+            ],
+            printColumns: [0, 1, 2, 3, 4, 5],
+            xlsColumns: [0, 1, 2, 3, 4, 5],
+            summation: [
+                {column: 3, dataType: 'number'},
+                {column: 4, dataType: 'number'},
+                {column: 5, dataType: 'number'}
+            ]
+        });
+
+        $campaignFilter.on("change", function () {
+            selectedCampaign = $(this).val() || "";
+            $summaryTable.appTable({reload: true, filterParams: {campaign: selectedCampaign}});
+            $breakdownTable.appTable({reload: true, filterParams: {campaign: selectedCampaign}});
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- update marketing source custom field IDs and related forms to use the new lead/client campaign fields
- add model queries and controller endpoints that combine leads and clients into a campaign pipeline summary and breakdown
- surface the campaign pipeline report in the UI with a dedicated view, navigation entry, and supporting translations

## Testing
- php -l app/Models/Clients_model.php
- php -l app/Controllers/Lead_reports.php
- php -l app/Controllers/Collect_leads.php
- php -l app/Helpers/reports_helper.php
- php -l app/Views/lead_reports/campaign_pipeline.php

------
https://chatgpt.com/codex/tasks/task_b_68e433bfbb44832a82bdbfd55aa93fb6